### PR TITLE
fix(test): update changelog tests for Keep a Changelog format

### DIFF
--- a/tests/test_sprint7.py
+++ b/tests/test_sprint7.py
@@ -105,13 +105,13 @@ class TestRelease:
 
     def test_changelog_has_version(self):
         content = (PROJECT_ROOT / "CHANGELOG.md").read_text()
-        assert "v1.0.0" in content
+        assert "1.0.0" in content
 
     def test_changelog_has_sections(self):
         content = (PROJECT_ROOT / "CHANGELOG.md").read_text()
-        assert "Core Features" in content
-        assert "Security" in content
-        assert "Quality" in content
+        # Keep a Changelog format uses ### Added, ### Security, etc.
+        assert "### Added" in content
+        assert "### Security" in content
 
     def test_roadmap_exists(self):
         assert (PROJECT_ROOT / "ROADMAP.md").exists()


### PR DESCRIPTION
## Summary
- Update 2 changelog tests that expected old format (`v1.0.0`, `Core Features`)
- Tests now match Keep a Changelog standard (`[1.0.0]`, `### Added`, `### Security`)

## Type
- [x] fix -- Bug fix

## Changes
- `tests/test_sprint7.py`: `test_changelog_has_version` now checks for `1.0.0` (without `v` prefix)
- `tests/test_sprint7.py`: `test_changelog_has_sections` now checks for `### Added` and `### Security` instead of `Core Features` and `Quality`

## Test Plan
- [x] Backend tests pass (`pytest tests/test_sprint7.py::TestRelease -v`)
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)