### PR TITLE
ci: skip full pipeline for docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,28 @@ name: CI/CD Pipeline
 on:
   push:
     branches: [main, develop]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
+      - 'class.md'
+      - 'CHANGELOG.md'
+      - 'CONTRIBUTING.md'
+      - 'CLAUDE.md'
+      - '.github/PULL_REQUEST_TEMPLATE.md'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
+      - 'class.md'
+      - 'CHANGELOG.md'
+      - 'CONTRIBUTING.md'
+      - 'CLAUDE.md'
+      - '.github/PULL_REQUEST_TEMPLATE.md'
 
 jobs:
   lint:

--- a/.github/workflows/docs-skip.yml
+++ b/.github/workflows/docs-skip.yml
@@ -1,0 +1,36 @@
+name: CI/CD Pipeline
+
+# Mirror trigger of main CI but ONLY for docs-only changes.
+# Provides the required "Lint" and "Test" check names so branch protection
+# allows merging docs PRs without running the full pipeline.
+
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
+      - '.github/PULL_REQUEST_TEMPLATE.md'
+  pull_request:
+    branches: [main]
+    paths:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
+      - '.github/PULL_REQUEST_TEMPLATE.md'
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Docs-only change — lint skipped."
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Docs-only change — tests skipped."


### PR DESCRIPTION
## Summary
- Docs-only changes (*.md, docs/, LICENSE, .gitignore) no longer trigger the full CI pipeline
- A lightweight workflow provides required check names so docs PRs can still merge

## Type
- [x] ci -- CI/CD changes

## Changes
- `.github/workflows/ci.yml`: Added `paths-ignore` for documentation files
- `.github/workflows/docs-skip.yml`: New lightweight workflow that satisfies branch protection checks for docs-only PRs

## Test Plan
- [x] CI workflow still triggers for code changes
- [x] Docs-only PRs get instant "Lint" and "Test" pass without running full pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)