### PR TITLE
docs: add Google SWE standards to class.md and update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,82 +2,170 @@
 
 All notable changes to this project will be documented in this file.
 
-Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] — v2.1.0
+## [Unreleased] - v2.1.0
 
 ### Added
-- **Upload progress tracking**: Instant screen switch on file drop with real-time XHR upload percentage
-- **Background model preloading**: Server accepts connections immediately, model loads in background (~60s saved)
-- **Model preload status indicator**: Spinner on model row while loading, green "Ready" badge when done
-- **Transcription detail panel**: Audio position bar, speed (Nx realtime), ETA countdown, elapsed time, segment counter
-- **Model selector redesign**: Card-based layout with research-accurate specs (params, WER, speed bars)
-- **Tooltips for abbreviations**: WER, ETA, realtime speed all have hover explanations
-- **Conventional Commits hook**: `commit-msg` hook validates all commits follow `type(scope): description`
-- **Pre-commit hook**: Blocks secrets, cert/key files, .env; runs ruff (Python) and eslint (frontend)
-- **Branch protection**: `main` branch requires CI checks (lint + test) to pass
-- **PR template**: `.github/PULL_REQUEST_TEMPLATE.md` with type checkboxes and test plan
-- **CI: Frontend testing**: GitHub Actions now runs Vitest + TypeScript checks alongside backend tests
-- **CONTRIBUTING.md**: Full contribution guidelines with git workflow, code standards, testing guide
-- **Git standards in CLAUDE.md**: Conventional Commits, GitHub Flow, semver documented
+- Multi-model preload support: `PRELOAD_MODEL` now accepts comma-separated values (e.g., `tiny,base,large`) or `all` to load every model
+- Background model preloading: models load after server starts accepting connections so the UI is available immediately
+- Model preload status API (`/api/model-status`) for frontend display of loading progress
+- Model preload status included in `/system-info` and `/api/system-status` endpoints
+- `MAX_CONCURRENT_TASKS` environment variable for explicit override of auto-tuned concurrency
+- Upload progress percentage display in the transcription form
+- Transcription detail panel with richer progress information
+- Model selector redesign with card-based layout and research-accurate specs
+- Conventional Commits hook and pre-commit hook for git standards
+- PR template and CONTRIBUTING.md with contribution guidelines
+- CI frontend testing: GitHub Actions now runs Vitest + TypeScript checks
 
 ### Changed
-- Pipeline message shows "Starting transcription with large model..." when model is cached (instead of misleading "Loading...")
-- Model selector data updated with accurate OpenAI Whisper paper specs (39M-1.55B params, WER benchmarks)
-- `MAX_CONCURRENT_TASKS` now configurable via env var (supports 10 concurrent users)
+- Pipeline transcription step shows "Starting transcription with X model..." when model is already cached instead of misleading "Loading..." message
+- `PRELOAD_MODEL` config updated from single-model to multi-model support
+- Concurrency tuning now respects explicit `MAX_CONCURRENT_TASKS` env var, skipping auto-tune override when set
+- Docker Compose passes `MAX_CONCURRENT_TASKS` env var to containers
+- Frontend SSE hook, progress view, and task store updated for richer transcription state tracking
 
 ### Fixed
-- ERR_CONNECTION_REFUSED during model preload (server now starts immediately)
-- Misleading "Loading model" message when model was already preloaded (0.002s cache hit)
+- ERR_CONNECTION_REFUSED during model preload (server now starts immediately, loads models in background)
+- Misleading "Loading model" message when model was already preloaded and cached
 
----
-
-## [2.0.0] — 2026-03-13
+## [2.0.0] - 2026-03-13
 
 ### Added
-- **Translation support**: Whisper built-in (any -> English) + Argos Translate (any-to-any, 100+ language pairs)
-- **Subtitle embedding improvements**: Soft mux and hard burn with ASS styling presets
-- **Public status page** at /status with auto-incident detection and uptime history
-- **Multi-server deployment**: ROLE env var (standalone/web/worker), Redis Pub/Sub, Celery, S3 storage
-- **Critical state system**: Health monitor auto-blocks uploads and aborts tasks on disk/DB/VRAM failure
-- **Database task backend**: PostgreSQL persistence with SQLAlchemy async + Alembic migrations
-- **Analytics dashboard**: Upload counters, timeseries, daily aggregates, data export
-- **SPA routing**: Client-side navigation for About, Contact, Security, Status pages
-- **Speaker diarization**: pyannote.audio integration with configurable speaker count
-- **Real-time SSE**: Server-sent events with exponential backoff, watchdog, heartbeat
-- **WebSocket support**: Alternative real-time transport alongside SSE and polling
-- **Audit trail**: All sensitive operations logged to PostgreSQL audit_log table
-- **Brute force protection**: Rate limiting middleware with exponential backoff
-- **ClamAV integration**: Optional virus scanning for uploads
-- **System capability detection**: Auto-tunes OMP threads, concurrent tasks, model selection at startup
-- **Worker health monitoring**: Background health checks for disk, DB, VRAM, workers
+- Argos Translate integration for any-to-any language translation (100+ language pairs, post-transcription step)
+- Whisper built-in translation (any language to English) exposed in the transcribe form
+- Translation batch progress events via SSE for real-time UI updates
+- React 18 + TypeScript + Vite frontend replacing Jinja2 server-rendered templates
+- Zustand state management (taskStore, uiStore) replacing ad-hoc DOM state
+- Client-side SPA navigation with session restore on reload
+- Public status page (`/status`) with auto-incident detection, uptime history, and 30s auto-refresh
+- Status page admin panel (`/status/manage`) for incident management
+- Deployment history section on status page with GitHub CI/CD badges and clickable commit SHA links
+- About, Contact, and Security static pages with fixed navigation header
+- `/security` page documenting attack prevention measures
+- Distributed architecture support: Redis Pub/Sub, Celery workers, nginx load balancer
+- `ROLE` environment variable for multi-server deployment (`standalone`, `web`, `worker`)
+- PostgreSQL shared task persistence via `DatabaseTaskBackend` with SQLAlchemy async and Alembic migrations
+- S3/MinIO optional shared file storage backend
+- `ENVIRONMENT` mode (`dev`/`prod`) for deployment flexibility
+- TLS support with Let's Encrypt certificates and HTTP-to-HTTPS redirect
+- Docker TLS support with bind-mount directory safety checks
+- Automated deployment script and DEPLOY.md guide
+- Standalone embed subtitles tab for local-file embedding (upload video + subtitle separately)
+- Embed style live preview on both transcription and standalone embed panels
+- Subtitle embedding improvements: soft mux and hard burn with ASS styling presets
+- Disk usage percentage in health panel with root filesystem fallback
+- Pipeline step tracking with step timing data emitted via SSE
+- Critical state system: health monitor auto-blocks uploads and aborts in-flight tasks on disk/DB/VRAM failure
+- Worker health monitoring: background checks for disk, DB, VRAM, workers
+- Audit trail: all sensitive operations logged to PostgreSQL `audit_log` table
+- ClamAV quarantine integration for optional virus scanning of uploads
+- Analytics dashboard with upload counters, timeseries, daily aggregates, and data export
+- Graceful FFmpeg feature degradation when FFmpeg is missing
+- Paginated subtitle editor to handle 10,000+ segments without lag
+- OWASP security test fixtures with real SQL injection, XSS, and path traversal payloads
+- E2E tests with Playwright (excluded from default pytest run)
+- MSW mocks, Vitest, and JSON schemas for parallel frontend/backend development
+- Test suite expanded to 1,326 tests (up from 307 in v1.0.0)
+
+### Changed
+- Frontend migrated from Jinja2 server-rendered templates to React SPA (Vite + TypeScript + Tailwind CSS)
+- UI redesigned with light theme replacing dark theme
+- Task Queue redesigned as fixed flex sidebar (always visible, no scrolling needed)
+- Embed panel simplified to soft-mux only with more prominent placement
+- Embed style options reduced to color + size only (from 6 presets)
+- Model info panel redesigned with structured card layout
+- Subtitle editor layout: timestamp stacked above textarea for full-width editing
+- Advanced Options panel removed from transcription form (settings moved inline)
+- Video preview and subtitle editor panels removed from output card
+- GitHub commits cache TTL tuned (30s for freshness, 300s with stale fallback on rate limit)
+- Status page polling reduced from 1s to 30s with server-side caching
+- Health status uses `asyncio.Lock` to serialize cache fills (prevents freeze on rapid refresh)
+- Blocking syscalls in health monitoring offloaded from event loop via `asyncio.to_thread`
+- Scrollbar styling unified between React and legacy Jinja2 pages (pill thumb, Firefox support)
+- Navigation header unified across all pages with consistent alignment
+- Technology credits updated across all UI surfaces
+- CLAUDE.md rewritten to reflect current architecture
+
+### Fixed
+- Server freeze on rapid F5 refresh (health cache serialization with asyncio.Lock)
+- Server freeze from blocking syscalls in event loop (health status offloaded to thread)
+- Embed button not showing after transcription without page refresh
+- Live subtitle preview not restoring after F5 refresh
+- Output panel not showing after transcription (stale refs to deleted Advanced Options elements)
+- Offline banner flickering during heavy CPU load
+- Disk percentage showing 0% (fallback to root filesystem when mount point unavailable)
+- Disk percent computation crashing health check in tests
+- HealthPanel props type mismatch in StatusPage
+- Commit card collapsing on refresh in deployment history
+- Jump-to-segment scrolling the browser window instead of the editor pane
+- Embed mode cards shifting layout on selection (description length and card sizing)
+- Pause timer bug and paused state reconnection after disconnect
+- UI state not persisting across Transcribe/Combine tab navigation
+- Download button visibility after transcription completion
+- Container crash from unwritable bind-mount directories
+- CI test failures: missing uploads dir, cross-platform path sanitization, sessionStorage to localStorage migration
+- Multiple ruff lint errors across routes and middleware modules
 
 ### Security
-- Magic bytes validation for uploaded files
-- Filename sanitization (path traversal, null bytes, special chars)
-- Security headers (CSP, HSTS, X-Frame-Options, X-Content-Type-Options)
-- API key authentication (optional, via X-API-Key header)
+- Fixed task enumeration (IDOR) vulnerability allowing access to other users' tasks
+- Fixed rate-limit proxy bypass vulnerability
+- Added dynamic OWASP assertion tests with real SQL injection, XSS, and path traversal fixtures
+- Brute force protection middleware with exponential backoff
 - Request body size limiting middleware
-- ffmpeg protocol whitelist + execution timeout
 
----
-
-## [1.0.0] — 2026-03-11
+## [1.0.0] - 2026-03-12
 
 ### Added
-- Core subtitle generation with faster-whisper (CTranslate2 engine)
-- 99 languages with auto-detection
+- AI-powered subtitle generation using faster-whisper (CTranslate2 engine)
+- Support for 99 languages with auto-detection
+- Output formats: SRT, VTT, JSON (with word-level timestamps)
+- GPU acceleration (CUDA) with automatic model selection based on VRAM
+- CPU fallback with hardware-aware optimization (OMP threads, model selection)
 - 5 Whisper models: tiny, base, small, medium, large
-- Output formats: SRT, VTT, JSON
-- GPU acceleration (CUDA) with automatic model selection
-- CPU fallback with hardware-aware optimization
 - Word-level timestamps for karaoke-style subtitles
-- Smart line-breaking (sentence/clause/word boundaries)
-- React SPA frontend with drag-and-drop upload
-- Real-time progress tracking
-- Docker support with CPU/GPU profiles
-- GitHub Actions CI/CD pipeline
-- 307+ automated tests
-- Health and readiness probes
-- Graceful shutdown with task draining
+- Speaker diarization via pyannote.audio (optional, graceful degradation)
+- Custom vocabulary via `initial_prompt` for domain-specific terms
+- Whisper translate mode (any language to English)
+- VAD filtering (Silero) for silence skipping
+- Smart line-breaking at sentence, clause, and word boundaries
+- Characters per second (CPS) validation (Netflix/YouTube standards)
+- Subtitle embedding: soft mux (MKV/MP4) and hard burn with ASS styling
+- 6 style presets: default, youtube_white, youtube_yellow, cinema, large_bold, top_position
+- In-browser subtitle editor with save/regenerate
+- Single-page web application with dark theme (Jinja2 templates)
+- Drag-and-drop file upload with batch processing
+- Real-time progress via SSE and WebSocket
+- Video preview with subtitle track overlay
+- Task queue visualization
+- Built-in monitoring dashboard (`/dashboard`)
+- System capability detection at startup (CPU, GPU, RAM, disk, OS)
+- Hardware-aware auto-tuning (threads, concurrency, model selection)
+- Structured JSON logging (`app.jsonl`) for ELK/Grafana/Loki integration
+- Request ID tracing across middleware, logs, and response headers
+- Global exception handler preventing service crashes
+- Background file cleanup (configurable 24h retention)
+- Task persistence across restarts (JSON file backend)
+- Dockerfile (CPU) + Dockerfile.gpu (NVIDIA CUDA) with non-root user
+- docker-compose.yml with CPU/GPU profiles
+- GitHub Actions CI/CD: lint, test, build, health check
+- API key authentication (`X-API-Key` header, optional)
+- Prometheus `/metrics` endpoint (zero-dependency)
+- Health (`/health`) and readiness (`/ready`) probes
+- Graceful shutdown with in-flight task draining
+- Session management via cookies with task ownership
+- Rate limiting via slowapi
+- 307 automated tests across 10 test modules
+- Cross-platform support (Linux, Windows, macOS, Docker)
+
+### Security
+- File extension allowlist + magic byte verification
+- Filename sanitization (path separators, null bytes, special chars)
+- File size limits (1KB - 2GB) and audio duration limit (4 hours)
+- ffmpeg protocol whitelist + execution timeout
+- Security headers: CSP, X-Frame-Options, X-Content-Type-Options
+- Path traversal prevention on downloads
+- Auth middleware, brute force protection, body size limits
+- Audit logging for sensitive operations

--- a/class.md
+++ b/class.md
@@ -1316,3 +1316,425 @@ Current version: `2.0.0` (from `app/main.py` FastAPI version).
 8. Retroactively tag past releases based on git history
 9. Add CONTRIBUTING.md referencing these standards
 10. Set up automated changelog generation from Conventional Commits
+
+---
+
+## 6. Google Software Engineering Standards
+
+This section maps practices from Google's engineering culture to the SubForge project, drawing primarily from *Software Engineering at Google* (Winters, Manshreck, Wright, 2020), the *Google SRE Book* (Beyer et al., 2016), Google's public style guides (https://google.github.io/styleguide/), and the release-please automation tool (https://github.com/googleapis/release-please).
+
+### 6.1 Code Review (Google Engineering Practices)
+
+Google treats code review as the single most important quality gate. Their publicly documented guidelines (https://google.github.io/eng-practices/) define three distinct approval dimensions and strict turnaround expectations.
+
+**Three approval dimensions:**
+
+| Dimension | What the reviewer checks | SubForge mapping |
+|-----------|------------------------|------------------|
+| **Correctness** | Does the code do what it claims? Are there bugs, race conditions, edge cases? | Any reviewer can approve correctness |
+| **Ownership** | Does this change belong in this part of the codebase? Does it fit the module architecture? | Module owners (route owner, service owner) approve ownership |
+| **Readability** | Does the code follow style, conventions, and idioms? Is it maintainable? | Readability-approved reviewers (those who know the project conventions) |
+
+**Key practices to adopt:**
+
+- **Small CLs (changelists):** Target < 400 lines per PR. Research shows reviewer effectiveness drops sharply after 400 lines. Large changes should be split into stacked PRs (e.g., refactor first, then feature, then tests).
+- **One business day turnaround:** Reviews should be completed within one business day. If you cannot review in time, reassign or acknowledge with an ETA.
+- **"Nit:" prefix:** Use `Nit:` for non-blocking style suggestions that the author can choose to address or ignore. This reduces review friction by clearly separating must-fix from nice-to-have.
+- **CODEOWNERS file:** GitHub's CODEOWNERS mechanism auto-assigns reviewers based on file paths, implementing Google's concept of per-directory ownership.
+
+**Action items for SubForge:**
+- Add a `CODEOWNERS` file mapping module paths to owners:
+  ```
+  # Backend
+  /app/services/pipeline.py    @backend-lead
+  /app/services/transcription.py @backend-lead
+  /app/routes/                 @backend-lead
+  /app/middleware/              @backend-lead
+  /app/db/                     @backend-lead
+
+  # Frontend
+  /frontend/src/               @frontend-lead
+
+  # Infrastructure
+  /docker-compose.yml          @infra-lead
+  /.github/                    @infra-lead
+  /deploy/                     @infra-lead
+  ```
+- Enforce PR size warnings: add a CI check or GitHub Action that warns when a PR exceeds 400 lines changed.
+- Document the three approval dimensions in the PR template so reviewers know what to look for.
+
+### 6.2 Testing (Google Test Pyramid)
+
+Google's testing philosophy is built around the test pyramid, size-based classification, and pragmatic rules like the Beyonce Rule.
+
+**Test pyramid target ratios:**
+
+| Layer | Target % | SubForge current state | What it covers |
+|-------|----------|----------------------|----------------|
+| Unit (Small) | ~80% | ~1300 tests in pytest, most are unit-level | Individual functions, classes, pure logic |
+| Integration (Medium) | ~15% | Some ASGI transport tests against FastAPI app | Module interactions, API contracts, DB queries |
+| E2E (Large) | ~5% | Playwright tests in `tests/e2e/` | Full browser flows, upload-to-download |
+
+**Test size definitions (Google internal classification):**
+
+| Size | Constraints | Time limit | SubForge examples |
+|------|------------|------------|-------------------|
+| **Small** | No I/O, no network, no disk, no sleep. Single process, single thread. | < 60 seconds | `test_srt.py`, `test_formatting.py`, pure function tests |
+| **Medium** | Localhost only (no external services). Can use disk, localhost network. | < 300 seconds | `test_api.py` (ASGI transport), `test_combine.py`, DB tests |
+| **Large** | Can access external services, real network, real GPU. | < 900 seconds | `tests/e2e/` (Playwright), full pipeline with real Whisper model |
+
+**The Beyonce Rule:** "If you liked it, then you shoulda put a test on it." If a behavior matters to your system, it must be covered by an automated test. Unwritten expectations are not contracts -- only tested behavior is guaranteed. This is especially relevant for SubForge's SSE event protocol, pipeline step ordering, and error handling paths.
+
+**DAMP over DRY in tests:** Google prefers tests that are "Descriptive and Meaningful Phrases" over "Don't Repeat Yourself." Test code should prioritize clarity over abstraction. Each test should be readable in isolation without jumping to shared helpers. Duplication in tests is acceptable when it makes the test self-documenting.
+
+**Flaky test target:** Google targets a flaky test rate below 0.15%. A flaky test is one that passes and fails without any code change. Flaky tests erode confidence in CI and train developers to ignore red builds. Track flaky tests explicitly and fix or quarantine them within one week.
+
+**Action items for SubForge:**
+- Add pytest markers for test sizes:
+  ```python
+  # conftest.py
+  import pytest
+
+  def pytest_configure(config):
+      config.addinivalue_line("markers", "small: unit tests, no I/O (< 60s)")
+      config.addinivalue_line("markers", "medium: integration tests, localhost only (< 300s)")
+      config.addinivalue_line("markers", "large: e2e tests, may use external services (< 900s)")
+  ```
+- Mark existing tests with `@pytest.mark.small`, `@pytest.mark.medium`, or `@pytest.mark.large`.
+- Configure fast presubmit to run only small tests: `pytest -m small`.
+- Add flaky test tracking: log test results over time and flag tests that fail intermittently.
+- Apply the Beyonce Rule to SSE event contracts, pipeline step ordering, and translation fallback paths.
+
+### 6.3 Documentation (Docs as Code)
+
+Google classifies documentation into five types, each serving a different audience and purpose. Documentation is treated as code: it lives in the repository, is reviewed in PRs, and is tested for freshness.
+
+**Five documentation types:**
+
+| Type | Purpose | SubForge example |
+|------|---------|-----------------|
+| **Reference** | API docs, function signatures, parameter descriptions | Swagger/OpenAPI auto-generated from FastAPI route docstrings |
+| **Design docs** | Explain *why* a system works the way it does, trade-offs considered | Architecture decisions (e.g., why Zustand over Redux, why SSE over WebSocket-only) |
+| **Tutorials** | Step-by-step guides for new users | "How to transcribe your first file" walkthrough |
+| **Conceptual** | Explain concepts needed to understand the system | Pipeline flow explanation, translation modes comparison |
+| **Landing pages** | Navigation hubs that point to other docs | CLAUDE.md serves this role currently |
+
+**Google Python docstring style:**
+```python
+def transcribe_audio(file_path: str, model_size: str = "base", language: str | None = None) -> list[dict]:
+    """Transcribe an audio file using faster-whisper.
+
+    Loads or reuses a cached model, extracts audio to WAV if needed,
+    and runs transcription with beam search.
+
+    Args:
+        file_path: Absolute path to the input audio or video file.
+        model_size: Whisper model size (tiny/base/small/medium/large).
+        language: ISO 639-1 language code, or None for auto-detection.
+
+    Returns:
+        List of segment dicts with keys: start, end, text, words.
+
+    Raises:
+        FileNotFoundError: If file_path does not exist.
+        TranscriptionError: If whisper fails to process the audio.
+    """
+```
+
+**Comments explain WHY, not WHAT:** Code should be self-documenting for *what* it does. Comments are reserved for *why* a particular approach was chosen, non-obvious constraints, or workarounds. Bad: `# increment counter`. Good: `# Retry up to 3 times because the model loader occasionally fails on first load due to a CTranslate2 race condition`.
+
+**Action items for SubForge:**
+- Add module-level docstrings to all files in `app/routes/` and `app/services/` explaining the module's responsibility and key behaviors.
+- Adopt Google-style docstrings (Args/Returns/Raises) for all public functions.
+- Audit existing comments: remove "what" comments, add "why" comments where trade-offs or workarounds exist.
+- Treat CLAUDE.md as the landing page; add links to design docs for major subsystems (pipeline, translation, embedding).
+
+### 6.4 Style Guides
+
+Google maintains language-specific style guides that are publicly available. The key principle: 90% of style rules should be auto-enforced by tooling, so code reviews focus on logic rather than formatting.
+
+**Google Python Style Guide key rules (https://google.github.io/styleguide/pyguide.html):**
+
+| Rule | Current SubForge state | Action |
+|------|----------------------|--------|
+| Import ordering (stdlib, third-party, local) | Not enforced | Enable ruff rule `I` (isort) |
+| No wildcard imports (`from x import *`) | Not enforced | Enable ruff rule `F403` (already in `F` selection) |
+| Naming: `snake_case` functions/vars, `PascalCase` classes | Followed by convention | No change needed |
+| Type hints on all public functions | Partial | Add mypy or pyright to CI |
+| Logging with `%s` format, not f-strings | Not followed (f-strings used in logging) | Enable ruff rule `G` (logging-format) |
+| No bare `except:` | Not enforced | Enable ruff rule `E722` (already in `E` selection) |
+| Avoid mutable default arguments | Not enforced | Enable ruff rule `B006` via `B` (bugbear) |
+| Use `collections.abc` for type hints, not `typing` | Not enforced | Enable ruff rule `UP` (pyupgrade) |
+
+**Google TypeScript Style Guide key rules (https://google.github.io/styleguide/tsguide.html):**
+
+| Rule | Current SubForge state | Action |
+|------|----------------------|--------|
+| Use `interface` over `type` for object shapes | Mixed usage | Add ESLint rule `@typescript-eslint/consistent-type-definitions` |
+| `const` by default, `let` only when reassignment needed | Mostly followed | No change needed |
+| No `any` type | PR checklist item, not enforced | Make `@typescript-eslint/no-explicit-any` an error |
+| Named exports over default exports | Mixed usage | Add ESLint rule `import/no-default-export` |
+| Use `readonly` for properties that should not change | Not enforced | Add `@typescript-eslint/prefer-readonly` |
+
+**Tooling enforcement target (90% auto-enforced):**
+
+| Tool | Purpose | Current | Target |
+|------|---------|---------|--------|
+| `ruff check` | Python linting | `E,F,W` rules only | Add `I,B,UP,SIM,G` rule sets |
+| `ruff format` | Python formatting | Not used | Enable, replace manual formatting |
+| ESLint | TypeScript linting | Configured but not blocking CI | Make blocking in CI |
+| mypy or pyright | Python type checking | Not configured | Add to CI with gradual strictness |
+| Prettier | Frontend formatting | Not configured | Add for consistent TS/CSS formatting |
+
+**Action items for SubForge:**
+- Expand ruff configuration to include rules `I` (import sorting), `B` (bugbear), `UP` (pyupgrade), `SIM` (simplification), and `G` (logging format).
+- Enable `ruff format` for consistent Python formatting.
+- Make ESLint a blocking CI check (fail the build on warnings).
+- Add mypy or pyright with gradual strictness (start with `--ignore-missing-imports`, tighten over time).
+
+### 6.5 CI/CD (Presubmit/Post-submit)
+
+Google splits CI into two stages: a fast presubmit that runs before merge, and a comprehensive post-submit that runs after merge. The key insight is that presubmit must be fast enough that developers never skip it.
+
+**Presubmit (< 2 minutes):**
+- Lint checks (ruff, ESLint, tsc)
+- Small (unit) tests only
+- Commit message format validation
+- Security scanning (no secrets in diff)
+
+**Post-submit (runs on main after merge):**
+- Full test suite (small + medium + large)
+- Code coverage calculation and threshold enforcement
+- Docker build verification
+- Dependency vulnerability scanning (pip-audit, npm audit)
+- Performance benchmarks (optional, track regressions)
+
+**Hermetic testing:** Tests should be fully self-contained and not depend on external state, network services, or execution order. SubForge already does this well with `sys.modules` patching for torch/whisper mocks and ASGI transport for API tests.
+
+**Configuration as code:** All CI configuration lives in version-controlled files (`.github/workflows/`), never in CI platform UI settings. Build steps should be reproducible locally.
+
+**Action items for SubForge:**
+- Split the current CI pipeline into two stages:
+  - **Fast presubmit:** `ruff check` + `tsc -b` + `pytest -m small` (target < 2 min)
+  - **Full post-submit:** All tests + coverage + Docker build + `pip-audit` + `npm audit`
+- Add `pytest -m small` as the presubmit test command.
+- Add `pytest --cov=app --cov-fail-under=70` to post-submit for coverage enforcement.
+- Ensure all CI steps can be run locally with a single `make ci-fast` or `make ci-full` command.
+
+### 6.6 SRE Practices (Four Golden Signals)
+
+Google's SRE book defines four golden signals that every service should monitor. These signals, combined with SLOs and error budgets, form the foundation of reliable operations.
+
+**Four Golden Signals:**
+
+| Signal | What to measure | SubForge implementation |
+|--------|----------------|------------------------|
+| **Latency** | Time to serve a request (p50, p95, p99) | Track per-route response times in `app/services/analytics.py`. Separate successful vs failed request latency. |
+| **Traffic** | Requests per second by endpoint | Already tracked via analytics counters. Add per-route breakdown. |
+| **Errors** | Error rate by type (4xx client, 5xx server, timeout) | Track via middleware. Separate validation errors (expected) from server errors (unexpected). |
+| **Saturation** | Resource utilization approaching limits | Already monitored: CPU, RAM, disk, VRAM via `health_monitor.py`. Add task queue depth (semaphore utilization). |
+
+**SLIs, SLOs, and SLAs:**
+
+| Term | Definition | SubForge example |
+|------|-----------|-----------------|
+| **SLI** (Service Level Indicator) | A quantitative measure of service behavior | "Percentage of /upload requests completing in < 5s" |
+| **SLO** (Service Level Objective) | A target value for an SLI | "99.5% of uploads complete in < 5s over a 30-day window" |
+| **SLA** (Service Level Agreement) | A contract with consequences for missing SLOs | Not applicable (internal service), but SLOs still drive prioritization |
+
+**Proposed SLOs for SubForge:**
+
+| SLO | Target | Measurement |
+|-----|--------|-------------|
+| Upload availability | 99.5% of uploads accepted (non-5xx) over 30 days | Error rate on POST /upload |
+| Transcription success rate | 99% of transcriptions complete without error | Pipeline completion rate |
+| API latency (non-transcription) | p99 < 500ms for health, download, status endpoints | Per-route latency tracking |
+| SSE delivery | 99.9% of pipeline events delivered to connected clients | Event delivery confirmation |
+
+**Error budgets:** If the SLO is 99.5% availability, the error budget is 0.5% (approximately 3.6 hours of downtime per month). When the error budget is nearly exhausted, freeze feature work and focus on reliability. When the error budget is healthy, invest in features.
+
+**Blameless postmortems:** When incidents occur, conduct a blameless postmortem focused on systemic causes, not individual blame. Document: what happened, timeline, root cause, what went well, what could be improved, and action items with owners. Store postmortems in a `postmortems/` directory in the repository.
+
+**Action items for SubForge:**
+- Define SLOs for the four golden signals (see proposed SLOs above).
+- Add latency percentile tracking (p50/p95/p99) to the analytics service, broken down by route.
+- Add task queue saturation metric: `active_tasks / MAX_CONCURRENT_TASKS`.
+- Create a postmortem template in `.github/POSTMORTEM_TEMPLATE.md`:
+  ```markdown
+  # Postmortem: [Incident Title]
+  **Date:** YYYY-MM-DD
+  **Duration:** X hours
+  **Impact:** [What was affected, how many users]
+
+  ## Timeline
+  - HH:MM — [Event]
+
+  ## Root Cause
+  [Systemic cause, not individual blame]
+
+  ## What Went Well
+  - [Thing that helped]
+
+  ## What Could Be Improved
+  - [Process gap]
+
+  ## Action Items
+  - [ ] [Action] — Owner: @person — Due: YYYY-MM-DD
+  ```
+
+### 6.7 Dependency Management
+
+Google is famously skeptical of external dependencies, governed by the principle of Hyrum's Law: "With a sufficient number of users of an API, all observable behaviors of your system will be depended on by somebody." This means that even patch-version upgrades can break your system if you depend on undocumented behavior.
+
+**Key practices:**
+
+- **Pin exact versions:** Use `==` in `requirements.txt`, not `>=` or `~=`. Lock files (`package-lock.json`) must be committed. Reproducible builds require deterministic dependency resolution.
+- **Audit for vulnerabilities:** Run `pip-audit` (Python) and `npm audit` (Node.js) in CI. Block merges on known high/critical CVEs.
+- **SemVer skepticism (Hyrum's Law):** Do not trust that a minor or patch version bump is backward-compatible. Always test after dependency upgrades. Treat every upgrade as potentially breaking.
+- **Minimize dependency count:** Every dependency is a liability (maintenance burden, security surface, build complexity). Before adding a dependency, ask: can we write this in < 100 lines? Is the dependency actively maintained? Does it pull in a large transitive tree?
+
+**Action items for SubForge:**
+- Pin all versions in `requirements.txt` to exact versions (`faster-whisper==1.1.0`, not `faster-whisper>=1.0`).
+- Commit `frontend/package-lock.json` (already done) and verify it is up to date.
+- Add `pip-audit` to CI post-submit stage:
+  ```yaml
+  - name: Audit Python dependencies
+    run: pip install pip-audit && pip-audit -r requirements.txt
+  ```
+- Add `npm audit` to CI post-submit stage:
+  ```yaml
+  - name: Audit Node dependencies
+    run: cd frontend && npm audit --audit-level=high
+  ```
+- Configure Dependabot (`.github/dependabot.yml`) for automated dependency update PRs:
+  ```yaml
+  version: 2
+  updates:
+    - package-ecosystem: "pip"
+      directory: "/"
+      schedule:
+        interval: "weekly"
+    - package-ecosystem: "npm"
+      directory: "/frontend"
+      schedule:
+        interval: "weekly"
+  ```
+
+### 6.8 Version Control (Trunk-Based Development)
+
+Google practices trunk-based development: all developers work off a single main branch, with short-lived feature branches that merge back quickly. This minimizes merge conflicts and integration pain.
+
+**Key practices:**
+
+- **Short-lived branches (< 1 week):** Branches that live longer than a week accumulate merge conflicts and integration risk. If a feature takes longer than a week, break it into smaller increments that can be merged independently.
+- **Small commits:** Each commit should represent a single logical change. This makes bisecting easier, code review faster, and reverts safer. Target < 400 lines per commit (same as PR size guidance).
+- **Feature flags over long branches:** Instead of keeping a feature branch alive until the feature is complete, merge incomplete features behind a flag. This keeps main moving forward and allows testing in production without exposing unfinished work.
+  ```python
+  # app/config.py
+  ENABLE_SPEAKER_DIARIZATION = os.getenv("ENABLE_SPEAKER_DIARIZATION", "true").lower() == "true"
+  ENABLE_BATCH_UPLOAD = os.getenv("ENABLE_BATCH_UPLOAD", "false").lower() == "true"  # WIP feature
+  ```
+- **release-please for automated versioning:** Google's open-source tool `release-please` (https://github.com/googleapis/release-please) automates version bumps and changelog generation from Conventional Commits. It creates a "release PR" that, when merged, tags the release and generates a GitHub Release with a changelog.
+
+**Action items for SubForge:**
+- Configure release-please via GitHub Action:
+  ```yaml
+  # .github/workflows/release.yml
+  name: Release
+  on:
+    push:
+      branches: [main]
+  jobs:
+    release:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: googleapis/release-please-action@v4
+          with:
+            release-type: python
+            package-name: subforge
+  ```
+- Tag the current state as `v2.0.0` (initial release baseline).
+- Tag the next release as `v2.1.0` after merging current pending work (multi-model preload, distributed deploy).
+- Enforce the one-week branch lifetime: add a CI check or bot that warns on branches older than 7 days.
+
+### 6.9 Deprecation
+
+Google's philosophy on deprecation is captured in the principle: "Code is a liability, not an asset." Every line of code has a maintenance cost: it must be understood, tested, secured, and migrated when dependencies change. Removing code is always a net positive if the code is no longer needed.
+
+**Two deprecation modes:**
+
+| Mode | Description | SubForge example |
+|------|------------|-----------------|
+| **Advisory** | Mark as deprecated with warnings, provide migration path, remove after grace period | Deprecating an old API endpoint version while the new one is available |
+| **Compulsory** | Set a hard removal deadline, actively migrate callers, remove on schedule | Removing a feature flag after the feature is fully launched |
+
+**Deprecation process:**
+1. **Identify:** Find unused or redundant code through usage analytics, test coverage gaps, and code review.
+2. **Announce:** Mark with `@deprecated` decorator/comment, log warnings on use, update docs.
+3. **Migrate:** Move callers to the replacement. Provide examples.
+4. **Remove:** Delete the code, remove tests, update imports.
+
+**Action items for SubForge:**
+- Audit for dead code: identify routes, services, and utility functions that are never called or tested.
+- Check for unused routes: compare `app/routes/__init__.py` registrations against actual frontend API calls in `frontend/src/api/client.ts`.
+- Check for unused services: look for service modules that are imported but never called from routes or pipeline.
+- Remove or consolidate redundant endpoints (e.g., if both polling and SSE provide the same data, consider deprecating polling).
+- Add a `@deprecated` decorator for Python functions scheduled for removal:
+  ```python
+  import warnings
+  import functools
+
+  def deprecated(reason: str):
+      def decorator(func):
+          @functools.wraps(func)
+          def wrapper(*args, **kwargs):
+              warnings.warn(
+                  f"{func.__name__} is deprecated: {reason}",
+                  DeprecationWarning,
+                  stacklevel=2,
+              )
+              return func(*args, **kwargs)
+          return wrapper
+      return decorator
+  ```
+
+### 6.10 Priority Action Items
+
+Ranked by impact-to-effort ratio, organized into three time horizons.
+
+**Immediate (this session):**
+
+| Action | Effort | Impact | Reference |
+|--------|--------|--------|-----------|
+| Add `*.pem` to `.gitignore` | 1 min | Prevents accidental secret commit | 6.7 Dependency Management |
+| Create `CODEOWNERS` file | 5 min | Auto-assigns reviewers, enforces ownership | 6.1 Code Review |
+| Enable `ruff format` | 5 min | Consistent Python formatting, eliminates style debates | 6.4 Style Guides |
+| Make ESLint blocking in CI | 5 min | Catches TypeScript issues before merge | 6.4 Style Guides |
+
+**Short-term (this month):**
+
+| Action | Effort | Impact | Reference |
+|--------|--------|--------|-----------|
+| Split CI into fast presubmit / full post-submit | 2 hours | Faster PR feedback loop (< 2 min presubmit) | 6.5 CI/CD |
+| Pin all dependency versions | 1 hour | Reproducible builds, prevents surprise breakage | 6.7 Dependency Management |
+| Add pytest markers `@pytest.mark.small/medium/large` | 2 hours | Enables fast presubmit with small tests only | 6.2 Testing |
+| Add `pip-audit` + `npm audit` to CI | 30 min | Catches known vulnerabilities automatically | 6.7 Dependency Management |
+| Add type annotations to all public functions | 4 hours | Better IDE support, catches bugs at development time | 6.4 Style Guides |
+
+**Medium-term (this quarter):**
+
+| Action | Effort | Impact | Reference |
+|--------|--------|--------|-----------|
+| Define and measure SLOs for four golden signals | 1 week | Data-driven reliability decisions, error budgets | 6.6 SRE Practices |
+| Add mypy/pyright to CI (gradual strictness) | 1 week | Catches type errors, improves maintainability | 6.4 Style Guides |
+| Add property-based testing (Hypothesis) for formatters | 3 days | Finds edge cases in SRT/VTT generation | 6.2 Testing |
+| Create incident runbook and postmortem template | 2 days | Structured incident response, blameless culture | 6.6 SRE Practices |
+| Implement golden signals dashboard (latency percentiles, error rates, saturation) | 1 week | Real-time visibility into service health | 6.6 SRE Practices |
+
+**References:**
+- *Software Engineering at Google* (Winters, Manshreck, Wright, O'Reilly, 2020) — Chapters on code review, testing, deprecation, dependency management, version control
+- *Site Reliability Engineering* (Beyer, Jones, Petoff, Murphy, O'Reilly, 2016) — Chapters on monitoring, SLOs, error budgets, postmortems
+- Google Python Style Guide: https://google.github.io/styleguide/pyguide.html
+- Google TypeScript Style Guide: https://google.github.io/styleguide/tsguide.html
+- Google Engineering Practices (Code Review): https://google.github.io/eng-practices/
+- release-please: https://github.com/googleapis/release-please


### PR DESCRIPTION
## Summary
- Add Section 6 to class.md: Google Software Engineering Standards (10 subsections)
- Update CHANGELOG.md with detailed v2.0.0 and v2.1.0 entries

## Type
- [x] docs -- Documentation only

## Test Plan
- [x] Docs-only change — no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)