### PR TITLE
fix(a11y): resolve P0 WCAG contrast failures and missing ARIA roles

### DIFF
--- a/frontend/src/components/transcribe/TranscribeForm.tsx
+++ b/frontend/src/components/transcribe/TranscribeForm.tsx
@@ -163,10 +163,12 @@ export function TranscribeForm({ onUpload }: Props) {
             <Skeleton className="h-7 w-14" />
           </div>
         ) : (
-          <div className="flex gap-2">
+          <div className="flex gap-2" role="radiogroup" aria-label="Select device">
             {systemInfo?.cuda_available && (
               <button
                 type="button"
+                role="radio"
+                aria-checked={device === 'cuda'}
                 onClick={() => setDevice('cuda')}
                 className={chipBase}
                 style={{
@@ -188,6 +190,8 @@ export function TranscribeForm({ onUpload }: Props) {
             )}
             <button
               type="button"
+              role="radio"
+              aria-checked={device === 'cpu'}
               onClick={() => setDevice('cpu')}
               className={chipBase}
               style={{
@@ -221,7 +225,7 @@ export function TranscribeForm({ onUpload }: Props) {
         {loading ? (
           <Skeleton className="h-48 w-full" />
         ) : (
-          <div className="flex flex-col gap-2">
+          <div className="flex flex-col gap-2" role="radiogroup" aria-label="Select transcription model">
             {MODELS.map((m) => {
               const info = MODEL_INFO[m]
               const isActive = model === m
@@ -237,6 +241,8 @@ export function TranscribeForm({ onUpload }: Props) {
                 <button
                   key={m}
                   type="button"
+                  role="radio"
+                  aria-checked={isActive}
                   onClick={() => setModel(m)}
                   className="w-full text-left rounded-lg border transition-all"
                   style={{
@@ -445,11 +451,13 @@ export function TranscribeForm({ onUpload }: Props) {
         >
           FORMAT
         </label>
-        <div className="flex gap-2">
+        <div className="flex gap-2" role="radiogroup" aria-label="Select output format">
           {FORMAT_OPTIONS.map((opt) => (
             <button
               key={opt.value}
               type="button"
+              role="radio"
+              aria-checked={format === opt.value}
               onClick={() => setFormat(opt.value)}
               className={chipBase}
               style={{

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -17,8 +17,8 @@
   --color-text-2:    #6B7280;
   --color-text-3:    #9CA3AF;
 
-  --color-primary:         #863bff;
-  --color-primary-hover:   #7326f0;
+  --color-primary:         #7c3aed;
+  --color-primary-hover:   #6d28d9;
   --color-primary-light:   #f3eeff;
   --color-primary-border:  #ddd6fe;
 
@@ -26,10 +26,10 @@
   --color-success-light:   #ECFDF5;
   --color-success-border:  #A7F3D0;
 
-  --color-warning:         #F59E0B;
+  --color-warning:         #b45309;
   --color-warning-light:   #FFFBEB;
 
-  --color-danger:          #EF4444;
+  --color-danger:          #b91c1c;
   --color-danger-light:    #FEF2F2;
 
   /* Radius */


### PR DESCRIPTION
## Summary
- Fix WCAG AA color contrast failures across primary, warning, and danger colors
- Add ARIA radiogroup/radio roles to model, device, and format selectors

Fixes #19
Fixes #22

## Type
- [x] fix -- Bug fix

## Changes

### Color Contrast (index.css) — Prism
| Token | Before | After | Contrast Ratio |
|-------|--------|-------|---------------|
| `--color-primary` | `#863bff` (3.2:1) | `#7c3aed` (5.02:1) | WCAG AA ✓ |
| `--color-warning` | `#F59E0B` (~2.5:1) | `#b45309` (4.84:1) | WCAG AA ✓ |
| `--color-danger` | `#EF4444` (4.1:1) | `#b91c1c` (5.91:1) | WCAG AA ✓ |
| `--color-primary-hover` | `#7326f0` | `#6d28d9` | — |

### ARIA Roles (TranscribeForm.tsx) — Prism
- Device selector: `role="radiogroup"` + `role="radio"` + `aria-checked`
- Model selector: `role="radiogroup"` + `role="radio"` + `aria-checked`
- Format selector: `role="radiogroup"` + `role="radio"` + `aria-checked`

## Test Plan
- [x] Frontend builds (`npx vite build`)
- [x] Frontend tests pass (23/23)
- [x] Backend tests pass (1187/1187)
- [x] `ruff check .` passes
- [x] Scout (QA) ✓ Hawk (Review) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)