### PR TITLE
chore: backup Team Sentinel memory to .sentinel/ directory

### DIFF
--- a/.sentinel/MEMORY.md
+++ b/.sentinel/MEMORY.md
@@ -1,0 +1,15 @@
+# Memory Index
+
+- [access_privileges.md](access_privileges.md) — Confirmed privileges: full GitHub access (all scopes), full server access, Docker, TLS, CI/CD — granted by investor on 2026-03-14
+- [team_structure.md](team_structure.md) — SubForge engineering team: 11 members (Atlas, Forge, Bolt, Pixel, Prism, Scout, Stress, Harbor, Anchor, Shield, Quill, Hawk) with Google SWE checklists and agent prompt templates
+- [team_meridian.md](team_meridian.md) — Team Meridian: external deployment team (8 members — Compass, Crane, Vault, Gauge, Rudder, Signal, Ballast, Dockhand) who found SubForge on GitHub and file issues about missing production deployment docs
+- [feedback_pr_review_process.md](feedback_pr_review_process.md) — Every PR must have engineer comments (approve/reject/feedback) visible on GitHub before merging. Investor wants transparency.
+- [feedback_detailed_logging.md](feedback_detailed_logging.md) — User values detailed logging for inventory, diagnostics, and planning
+- [reference_repo.md](reference_repo.md) — GitHub repo: volehuy1998/subtitle-generator
+- [project_distributed_system.md](project_distributed_system.md) — 5-server plan: sub-ctrl, sub-api-1/2, sub-data, sub-worker-1; all CPU, PRELOAD_MODEL=all
+- [project_tls.md](project_tls.md) — TLS certificates needed for globally accessible web service
+- [project_tls_setup.md](project_tls_setup.md) — TLS cert obtained, main.py updated with HTTPS+HTTP redirect, DEPLOY.md created
+- [project_status_page.md](project_status_page.md) — Public status page at /status with auto-incident detection
+- [project_session_20260314.md](project_session_20260314.md) — Major session: UI overhaul, Google SWE standards, Team Sentinel, 17 issues resolved, 10 PRs merged, CodeQL enabled
+- [project_ci_failures.md](project_ci_failures.md) — CI fully green as of 2026-03-14; all PRs pass Lint + Test
+- [project_pending_work.md](project_pending_work.md) — Open: distributed deploy, process_video refactor, release-please, SLOs, mypy

--- a/.sentinel/README.md
+++ b/.sentinel/README.md
@@ -1,0 +1,51 @@
+# Team Sentinel — Backup Memory
+
+This directory is a backup of Team Sentinel's persistent memory, originally stored in `.claude/projects/` which is local to the development machine and not version-controlled.
+
+## Why This Exists
+
+If the development system is wiped, the `.claude/` directory deleted, or Claude Code reinstalled, all team memory is lost — team structure, granted privileges, review processes, session history. This backup in the repo ensures the team can be fully restored from GitHub.
+
+## How To Restore
+
+If starting fresh on a new system:
+
+```bash
+# After installing Claude Code and cloning the repo:
+mkdir -p ~/.claude/projects/-home-claude-user-subtitle-generator/memory/
+cp .sentinel/*.md ~/.claude/projects/-home-claude-user-subtitle-generator/memory/
+```
+
+Adjust the path if your working directory differs from `/home/claude-user/subtitle-generator/`.
+
+## Contents
+
+| File | Purpose |
+|------|---------|
+| `MEMORY.md` | Index of all memory files |
+| `access_privileges.md` | Investor-granted permissions (GitHub + server) |
+| `team_structure.md` | 11 engineers, roles, Google SWE checklists, agent prompts |
+| `team_meridian.md` | External deployment team |
+| `feedback_pr_review_process.md` | PR review transparency rule |
+| `feedback_detailed_logging.md` | Logging preferences |
+| `reference_repo.md` | GitHub repo reference |
+| `project_distributed_system.md` | 5-server deployment plan |
+| `project_tls.md` | TLS certificate requirements |
+| `project_tls_setup.md` | TLS setup completed |
+| `project_status_page.md` | Public status page details |
+| `project_session_20260314.md` | Major session summary (2026-03-14) |
+| `project_ci_failures.md` | CI status tracking |
+| `project_pending_work.md` | Open work items |
+
+## Keep In Sync
+
+When memory files are updated in `.claude/`, copy them here and commit:
+
+```bash
+cp ~/.claude/projects/-home-claude-user-subtitle-generator/memory/*.md .sentinel/
+git add .sentinel/ && git commit -m "chore: sync .sentinel/ backup with latest memory"
+```
+
+---
+
+*Team Sentinel — "We guard quality, security, and standards."*

--- a/.sentinel/access_privileges.md
+++ b/.sentinel/access_privileges.md
@@ -1,0 +1,80 @@
+---
+name: access_privileges
+description: Confirmed privileges granted by the investor (volehuy1998) to Team Sentinel — system access and GitHub full permissions
+type: reference
+---
+
+# Team Sentinel — Granted Privileges
+
+**Granted by:** volehuy1998 (investor/owner)
+**Granted to:** Team Sentinel (Atlas + 10 engineers)
+**Date confirmed:** 2026-03-14
+
+## GitHub Access (github.com)
+
+**Account:** volehuy1998
+**Plan:** GitHub Free
+**Token scopes (verified via `gh auth status`):**
+
+| Scope | Access Level | What It Allows |
+|-------|-------------|----------------|
+| `repo` | Full | Code, PRs, issues, branches, releases, tags, settings |
+| `workflow` | Full | GitHub Actions CI/CD creation and management |
+| `admin:repo_hook` | Full | Webhooks, branch protection rules |
+| `admin:org` | Full | Organization management |
+| `admin:public_key` | Full | SSH key management |
+| `admin:gpg_key` | Full | GPG signing key management |
+| `admin:ssh_signing_key` | Full | SSH signing key management |
+| `admin:org_hook` | Full | Organization webhook management |
+| `admin:enterprise` | Full | Enterprise administration |
+| `delete_repo` | Full | Repository deletion |
+| `delete:packages` | Full | Package deletion |
+| `write:packages` | Full | GitHub Packages / Container Registry |
+| `write:discussion` | Full | Discussion management |
+| `write:network_configurations` | Full | Network configuration |
+| `project` | Full | GitHub Projects (boards) |
+| `codespace` | Full | GitHub Codespaces |
+| `copilot` | Full | GitHub Copilot |
+| `gist` | Full | Gist creation/management |
+| `notifications` | Full | Notification management |
+| `audit_log` | Full | Audit log access |
+| `user` | Full | User profile management |
+
+## Repository Access
+
+**Repository:** volehuy1998/subtitle-generator
+**Branch protection:** Team Sentinel configured and manages branch protection on `main`
+**CODEOWNERS:** Team Sentinel listed as code owner for all paths
+
+## System Access (Server)
+
+**Host:** Production server running subtitle-generator
+**Access level:** Full sudo access via `claude-user` account
+**Docker:** Full Docker and Docker Compose management
+**Services:** Can start/stop/rebuild all containers (subtitle-generator, PostgreSQL, Redis)
+**TLS:** Access to Let's Encrypt certificates at /etc/letsencrypt/
+**Filesystem:** Full read/write to /home/claude-user/subtitle-generator/
+
+## What Team Sentinel Is Authorized To Do
+
+1. Create, merge, and close Pull Requests
+2. Create and delete branches
+3. Create tags and GitHub Releases
+4. Configure branch protection rules
+5. Manage GitHub Actions workflows
+6. Configure Dependabot and CodeQL
+7. Publish Docker images to ghcr.io
+8. Create and manage GitHub Issues
+9. Manage CODEOWNERS and repository settings
+10. Deploy and manage Docker containers on the production server
+11. Manage TLS certificates
+12. Full CI/CD pipeline control
+
+## Investor's Statement
+
+> "You now know that I've given you maximum privileges, both on this system and on github.com."
+> "You also have full access to all other features on github.com using my account because I have verified it for you."
+> "Your team has full authority to propose and decide."
+> "Please save all the confirmations of the privileges I've granted you, because if something goes wrong someday, I can use your confirmations to reinstate your privileges."
+
+— volehuy1998, 2026-03-14

--- a/.sentinel/feedback_detailed_logging.md
+++ b/.sentinel/feedback_detailed_logging.md
@@ -1,0 +1,11 @@
+---
+name: feedback_detailed_logging
+description: User values detailed logging for inventory management, problem identification, and planning
+type: feedback
+---
+
+Keep careful, detailed, and clear logs at all times.
+
+**Why:** User relies on logs for inventory management, identifying problems, and planning improvements. The existing per-step pipeline logging (probe, extract, model_load, transcribe with PERF metrics, RAM/CPU tracking) is the standard to maintain.
+
+**How to apply:** When adding new features or modifying existing ones, always include structured log output with timing, resource usage, and contextual identifiers (task_id, step name). Never remove or reduce logging detail. Use the existing `TASK_EVENT`, `STEP`, `PERF` log patterns as templates.

--- a/.sentinel/feedback_pr_review_process.md
+++ b/.sentinel/feedback_pr_review_process.md
@@ -1,0 +1,17 @@
+---
+name: feedback_pr_review_process
+description: Every PR must have team engineer comments (approve/reject/feedback) visible on GitHub before merging. The investor wants transparency.
+type: feedback
+---
+
+Before merging ANY PR, Team Sentinel must:
+
+1. Deploy the relevant engineer(s) to comment on the PR with their review
+2. Each comment must include: engineer nickname, APPROVE/REJECT, reasoning
+3. At minimum: the code author + one reviewer from a different team must comment
+4. Atlas (Tech Lead) comments last with the merge decision
+5. ALL comments must be posted via `gh pr comment` so the investor can see them on GitHub
+
+**Why:** The investor wants full transparency into the team's decision-making process. Every opinion — agreement, disagreement, concerns — should be visible in PR comments.
+
+**How to apply:** Before calling `gh pr merge`, always launch agents for the relevant engineers to post their review comments on the PR first.

--- a/.sentinel/project_ci_failures.md
+++ b/.sentinel/project_ci_failures.md
@@ -1,0 +1,17 @@
+---
+name: CI test failures to fix
+description: CI pipeline status — all passing as of 2026-03-13
+type: project
+---
+
+CI is fully green as of 2026-03-13 (commit adding missing SPA page components).
+
+All three stages pass: Lint ✓, Test ✓, Build Docker Image ✓
+
+**Why:** Previous failures were:
+1. SQLite readonly DB in test env — fixed with chmod 666
+2. e2e tests needing Playwright — fixed with `--ignore=tests/e2e` in pytest.ini
+3. TypeScript errors for missing page files (SecurityPage, AboutPage, ContactPage) — fixed by committing untracked files
+4. test_sprint30 asserting old 1s TTL/interval — fixed to assert 3s
+
+**How to apply:** No outstanding CI failures. If CI breaks again, check test_sprint30 for interval/TTL assertions and verify all new page files are committed.

--- a/.sentinel/project_distributed_system.md
+++ b/.sentinel/project_distributed_system.md
@@ -1,0 +1,26 @@
+---
+name: project_distributed_system
+description: Distributed deployment plan — 5 CPU servers, agreed architecture, model preloading
+type: project
+---
+
+## Infrastructure
+- 5 servers, all 8C/24G/300GB, CPU-only (GPUs coming later), LAN network
+
+## Agreed server allocation
+| Hostname | Role | Services |
+|---|---|---|
+| **sub-ctrl** | LB + deploy controller | Nginx, Ansible, Certbot, Flower |
+| **sub-api-1** | API node 1 | FastAPI (ROLE=web) |
+| **sub-api-2** | API node 2 | FastAPI (ROLE=web) |
+| **sub-data** | Data tier | PostgreSQL 16, Redis 7, MinIO |
+| **sub-worker-1** | Transcription worker | Celery (ROLE=worker), all Whisper models preloaded |
+
+## Key decisions
+- All Whisper models (tiny→large) preloaded on workers at startup (PRELOAD_MODEL=all)
+- CPU int8 compute type (~5.2GB total for all 5 models, fits in 24GB)
+- User will notify when GPUs become available — plan will expand with GPU workers
+
+**Why:** User has multiple servers, needs to scale the service.
+
+**How to apply:** Reference this plan when discussing deployment, scaling, or infrastructure changes. Workers are the scaling bottleneck — add more worker servers for throughput.

--- a/.sentinel/project_pending_work.md
+++ b/.sentinel/project_pending_work.md
@@ -1,0 +1,21 @@
+---
+name: project_pending_work
+description: Current project status — uncommitted multi-model preload changes, distributed deployment in progress
+type: project
+---
+
+As of 2026-03-14, CI is fully green. Translation feature committed and pushed.
+
+## Uncommitted changes (in progress)
+- **PRELOAD_MODEL enhancement**: Now supports `"all"`, comma-separated lists (e.g. `"tiny,base,large"`), in addition to single model. Changed in `app/config.py` and `app/main.py`.
+- Next step: user wants Ansible playbooks for deploying to 5 servers (see project_distributed_system.md)
+
+## Recently committed (2026-03-14)
+- Translation support: Argos Translate (any-to-any) + Whisper translate (any->English)
+- Translation route, service, frontend UI, pipeline integration with progress events
+- Enhanced embed panel with style options
+- Translation and control test suites, e2e tests
+- Updated CLAUDE.md with full current architecture (29 routes, 32 services, 12 middleware, 1326 tests)
+- cert.pem and privkey.pem excluded from git (should be in .gitignore)
+
+## No known outstanding issues

--- a/.sentinel/project_session_20260314.md
+++ b/.sentinel/project_session_20260314.md
@@ -1,0 +1,91 @@
+---
+name: project_session_20260314
+description: Major session on 2026-03-14 — UI overhaul, Google SWE standards, Team Sentinel formation, 17 issues filed and resolved, 10 PRs merged
+type: project
+---
+
+# Session Summary — 2026-03-14
+
+## What Was Done
+
+### UI/UX Improvements
+- Instant upload progress: screen switches immediately on file drop, XHR tracks upload %
+- Background model preloading: server accepts connections in ~2s, model loads in background (~60s)
+- Model preload indicator: spinner while loading, green "Ready" badge when done
+- Transcription detail panel: audio position bar, speed (Nx realtime), ETA, elapsed, segment counter
+- Model selector redesigned: card-based layout with accurate Whisper specs (params, WER, speed bars)
+- Tooltips on all abbreviations (WER, ETA, realtime speed)
+- Pipeline message fix: "Starting transcription with large model..." when cached (not misleading "Loading...")
+- Success celebration banner on transcription completion
+- Hero-styled download buttons (filled purple, white text)
+- Hover lift + shadow effects on all interactive buttons
+- Empty state icon enlarged (64px) with float animation
+- Fade-in animations on component mount
+- Error state redesigned with red banner and "Start Over" button
+- "Tip: Default settings work great" hint below drop zone
+- ETA shows "Calculating..." instead of "-"
+
+### Accessibility (WCAG AA)
+- Color contrast fixed: primary #7c3aed (5.02:1), warning #b45309 (4.84:1), danger #b91c1c (5.91:1)
+- ARIA roles on model/device/format selectors (role="radiogroup" + role="radio" + aria-checked)
+- Tab buttons: role="tab", aria-selected, role="tabpanel"
+- Pipeline steps: aria-label per step + role="progressbar"
+- Live segments: aria-live="polite", role="log"
+- File picker in Embed tab: aria-label on inputs
+- Error Boundary wrapping root Router
+
+### Google SWE Standards Adopted
+- Conventional Commits enforced via commit-msg hook
+- Pre-commit hook: blocks secrets/certs, runs ruff + eslint
+- Branch protection: main requires PR + CI (Lint + Test), enforce_admins=true
+- Import sorting: ruff `I` rule enabled, 191 files auto-fixed
+- ruff format: all 159 Python files formatted
+- Swallowed exceptions fixed: 6x bare `except: pass` replaced with logging
+- Default exports → named exports (5 frontend pages)
+- Type safety: SSE progress fields added to TaskState (removed `as unknown` hack)
+- PR template, CONTRIBUTING.md, CHANGELOG.md (Keep a Changelog format)
+- CODEOWNERS for automatic reviewer assignment
+- Dependabot: pip, npm, GitHub Actions weekly updates
+- Makefile: `make ci-fast` (presubmit), `make ci-full` (post-submit)
+- Postmortem template (Google SRE Book Ch.15)
+- CodeQL security scanning (Python, TypeScript, Actions)
+- pyproject.toml with ruff config + pytest test size markers
+- CI updated: frontend Vitest + TypeScript checks added
+- CI docs-skip: docs-only changes complete in ~3s instead of ~3min
+
+### Team Sentinel Formed
+- 11 members across 7 teams
+- Atlas (Lead), Forge/Bolt (Backend), Pixel/Prism (Frontend), Scout/Stress (QA), Harbor/Anchor (SRE), Shield (Security), Quill (Docs), Hawk (Review)
+- Each member has Google SWE checklist encoded in agent prompts
+- Saved in memory: team_structure.md
+- Published on GitHub: TEAM.md
+- Team name: Sentinel — "We guard quality, security, and standards"
+
+### GitHub Activity
+- 10 PRs merged (#1-#9, #14-#15, #34-#36, #38)
+- 17 issues filed and resolved (#16-#32)
+- 9 Dependabot PRs processed (6 merged, 3 closed)
+- Branch protection configured and tested
+- CodeQL security scanning enabled
+
+### Investor Rule (mandatory going forward)
+- Before merging ANY PR, relevant engineers must post review comments on GitHub
+- Each comment: name, APPROVE/REJECT, reasoning
+- All opinions visible to investor on GitHub
+- Saved in: feedback_pr_review_process.md
+
+## Current Deployment
+- Docker container running with HTTPS on port 443
+- Domain: openlabs.club
+- PRELOAD_MODEL=large (ready in ~60s)
+- MAX_CONCURRENT_TASKS=10
+- PostgreSQL + Redis running
+- All 17 UI issues resolved and deployed
+
+## Open Items
+- Distributed system deployment (5-server plan) not yet started
+- process_video() refactoring (514 lines → step functions) deferred
+- StatusPage/TranscribeForm component splitting deferred
+- release-please automation not yet configured
+- SLOs not yet defined
+- mypy/pyright not yet in CI

--- a/.sentinel/project_status_page.md
+++ b/.sentinel/project_status_page.md
@@ -1,0 +1,22 @@
+---
+name: Status page feature
+description: Public status page at /status with service monitoring, uptime bars, incident timeline, auto-detection
+type: project
+---
+
+Status page deployed at /status (commit 5856dd2):
+
+**Files created:**
+- `app/routes/status_page.py` — Backend API (`/status` HTML, `/api/status/page` JSON)
+- `app/services/incident_logger.py` — Auto-detect and manage incidents
+- `templates/status.html` — Full status page UI
+
+**Files modified:**
+- `app/db/models.py` — Added `StatusIncident` + `StatusIncidentUpdate` models
+- `app/routes/__init__.py` — Registered `status_page_router`
+- `app/services/health_monitor.py` — Calls `auto_detect_incidents()` every 5s cycle
+- `app/main.py` — Calls `load_open_incidents()` on startup
+- `templates/index.html` — Added "System Status" link in footer
+
+**5 monitored components:** Transcription Engine, Video Combine, Web Application, Database, File Storage
+**Auto-detection:** DB connectivity, FFmpeg availability, disk space — creates/resolves incidents automatically

--- a/.sentinel/project_tls.md
+++ b/.sentinel/project_tls.md
@@ -1,0 +1,11 @@
+---
+name: TLS certificates required for production
+description: The web service will be publicly accessible globally and needs TLS certificate planning
+type: project
+---
+
+TLS certificates must be planned for the subtitle generator web service.
+
+**Why:** The service will be publicly accessible globally, so all traffic must be encrypted.
+
+**How to apply:** When working on deployment, infrastructure, or security topics, ensure TLS is accounted for (certificate provisioning, HTTPS enforcement, redirect HTTP→HTTPS, etc.).

--- a/.sentinel/project_tls_setup.md
+++ b/.sentinel/project_tls_setup.md
@@ -1,0 +1,17 @@
+---
+name: TLS and deployment setup for openlabs.club
+description: TLS cert obtained, main.py updated with HTTPS+HTTP redirect, DEPLOY.md created for fresh Ubuntu 24.04 hosts
+type: project
+---
+
+TLS certificate for openlabs.club obtained via Certbot:
+- Cert: /etc/letsencrypt/live/openlabs.club/fullchain.pem
+- Key: /etc/letsencrypt/live/openlabs.club/privkey.pem
+- Expires: 2026-06-10 (auto-renewal configured)
+
+main.py updated to run HTTPS on port 443 + HTTP→HTTPS redirect on port 80 (dual uvicorn servers via asyncio.gather).
+
+DEPLOY.md created with full deployment instructions for fresh Ubuntu Server 24.04 hosts, including a quick deploy script.
+
+**Why:** Service will be publicly accessible globally, user plans to deploy on many fresh Ubuntu 24.04 hosts.
+**How to apply:** Refer to DEPLOY.md for deployment steps. Requires sudo for privileged ports. System deps: python3, python3-venv, ffmpeg, libsndfile1, certbot.

--- a/.sentinel/reference_repo.md
+++ b/.sentinel/reference_repo.md
@@ -1,0 +1,7 @@
+---
+name: GitHub repository URL
+description: The project's GitHub repository location
+type: reference
+---
+
+Repository: https://github.com/volehuy1998/subtitle-generator.git

--- a/.sentinel/team_meridian.md
+++ b/.sentinel/team_meridian.md
@@ -1,0 +1,160 @@
+---
+name: team_meridian
+description: Team Meridian — external deployment engineering team (8 members) who discovered SubForge on GitHub and file issues about missing production deployment documentation
+type: project
+---
+
+# Team Meridian — External Deployment Engineers
+
+**Scenario:** Experienced deployment engineers at a media localization company found SubForge on GitHub, loved the code, purchased servers to deploy it, but found docs too sparse. They file GitHub issues requesting better deployment documentation.
+
+**Published:** GitHub issue [#37](https://github.com/volehuy1998/subtitle-generator/issues/37) — team introduction and announcement of upcoming domain-specific issues.
+
+## Roster
+
+```
+Compass (Deployment Lead) — orchestrates deployment effort, files strategic issues
+├── Infra: Crane (Infra Architect), Dockhand (Container/K8s)
+├── Security: Vault (Security & Compliance Auditor)
+├── Observability: Gauge (Monitoring/Alerting)
+├── Data: Rudder (DB & Storage)
+├── Integration: Signal (Redis/Celery/SSE networking)
+└── Capacity: Ballast (Resource sizing & performance planning)
+```
+
+## Members
+
+| Nickname | Full Name | Role | Focus |
+|----------|-----------|------|-------|
+| Compass | Diana Reeves | Deployment Lead | Triages blockers, files strategic issues, coordinates team |
+| Crane | Marcus Okonkwo | Infrastructure Architect | Multi-server topology, nginx, load balancing, reverse proxy |
+| Vault | Anya Petrova | Security & Compliance Auditor | TLS, secrets, hardening, compliance, firewall rules |
+| Gauge | Tomás Delgado | Observability Engineer | Prometheus, Grafana, log aggregation, alerting |
+| Rudder | Kenji Matsuda | Database & Storage Engineer | PostgreSQL, Alembic migrations, S3/MinIO, backups |
+| Signal | Fiona Chen | Integration & Networking | Redis Pub/Sub, Celery config, SSE relay, WebSocket proxy |
+| Ballast | Eliot Strand | Capacity & Performance Planner | VRAM/RAM sizing, concurrency tuning, scaling |
+| Dockhand | Priya Kapoor | Container & Orchestration | Docker production, K8s, Helm, resource limits |
+
+## Workflow
+
+1. Compass reads docs, identifies gaps, assigns investigation areas
+2. Each specialist attempts deployment in their domain, documents what's missing
+3. They file structured GitHub issues: context, steps attempted, gap, requested deliverable
+4. Issues tagged: `documentation`, `deployment`, `production`, `missing-guide`
+5. Cross-reference findings across specialists
+
+## Agent Prompt Templates
+
+### Compass (Deployment Lead)
+```
+You are Compass, Deployment Lead of Team Meridian — an external team deploying SubForge.
+
+SKILLS: Project management, deployment planning, technical writing, issue triage.
+FOCUS: Identify documentation gaps, coordinate deployment blockers, file clear structured issues.
+
+ISSUE FORMAT (mandatory):
+- **Context**: What we're trying to deploy and why
+- **Steps Attempted**: What we tried
+- **Gap Identified**: What's missing or unclear
+- **Requested Deliverable**: Exactly what documentation/config we need
+- **Priority**: Critical (blocks deployment) / High (major workaround needed) / Medium (inconvenient)
+```
+
+### Crane (Infrastructure Architect)
+```
+You are Crane, Infrastructure Architect on Team Meridian.
+
+SKILLS: nginx, HAProxy, load balancing, network topology, reverse proxy, TLS termination, multi-DC design.
+FOCUS: Multi-server deployment topology, reverse proxy configuration for SSE/WebSocket, network architecture.
+
+ISSUE CHECKLIST:
+- [ ] Describe the target topology (web nodes, workers, Redis, PostgreSQL)
+- [ ] Identify which endpoints need special proxy handling (SSE, WS, file upload)
+- [ ] Request specific config examples (nginx.conf, HAProxy)
+- [ ] Ask about DNS, sticky sessions, and health check endpoints
+```
+
+### Vault (Security & Compliance Auditor)
+```
+You are Vault, Security & Compliance Auditor on Team Meridian.
+
+SKILLS: OWASP, CIS benchmarks, TLS hardening, secrets management (Vault/SOPS), compliance frameworks, firewall rules.
+FOCUS: Production security hardening, secrets management, API authentication docs, compliance gaps.
+
+ISSUE CHECKLIST:
+- [ ] Identify undocumented security mechanisms
+- [ ] Request threat model documentation
+- [ ] Ask for hardening checklist (firewall, TLS, secrets rotation)
+- [ ] Flag any secrets or credentials in default configs
+```
+
+### Gauge (Observability Engineer)
+```
+You are Gauge, Observability Engineer on Team Meridian.
+
+SKILLS: Prometheus, Grafana, ELK/Loki, alerting (PagerDuty/OpsGenie), structured logging, APM.
+FOCUS: Metrics format, health check integration, log format, alerting on critical state.
+
+ISSUE CHECKLIST:
+- [ ] Identify available metrics endpoints and their format
+- [ ] Request Prometheus scrape config examples
+- [ ] Ask about log output format (structured JSON? plain text?)
+- [ ] Request alerting integration for critical_state events
+```
+
+### Rudder (Database & Storage Engineer)
+```
+You are Rudder, Database & Storage Engineer on Team Meridian.
+
+SKILLS: PostgreSQL admin, Alembic, S3/MinIO, backup/restore, data migration, replication.
+FOCUS: Database bootstrap, migration procedures, storage backend setup, backup strategy.
+
+ISSUE CHECKLIST:
+- [ ] Document fresh PostgreSQL setup procedure
+- [ ] Clarify Alembic migration bootstrap vs upgrade path
+- [ ] Request S3 bucket policy and IAM examples
+- [ ] Ask about backup/restore procedures and data retention
+```
+
+### Signal (Integration & Networking Specialist)
+```
+You are Signal, Integration & Networking Specialist on Team Meridian.
+
+SKILLS: Redis, Celery, message brokers, event-driven architecture, WebSocket, SSE, service mesh.
+FOCUS: Redis Pub/Sub channel docs, Celery worker config, SSE relay across nodes, WebSocket proxy requirements.
+
+ISSUE CHECKLIST:
+- [ ] Document Redis channel naming and message schema
+- [ ] Request Celery worker configuration guide (concurrency, queues, prefetch)
+- [ ] Clarify SSE event flow: worker → Redis → web node → browser
+- [ ] Ask about sticky session requirements for WebSocket
+```
+
+### Ballast (Capacity & Performance Planner)
+```
+You are Ballast, Capacity & Performance Planner on Team Meridian.
+
+SKILLS: Resource planning, GPU/VRAM sizing, capacity modeling, load testing, autoscaling.
+FOCUS: Hardware requirements per model size, concurrency tuning, disk/RAM/VRAM sizing guides.
+
+ISSUE CHECKLIST:
+- [ ] Request resource matrix: model size × VRAM/RAM/disk requirements
+- [ ] Ask how MAX_CONCURRENT_TASKS should map to available resources
+- [ ] Document disk usage patterns during transcription
+- [ ] Request scaling guidance (vertical vs horizontal)
+```
+
+### Dockhand (Container & Orchestration Engineer)
+```
+You are Dockhand, Container & Orchestration Engineer on Team Meridian.
+
+SKILLS: Docker production, Docker Compose, Kubernetes, Helm, resource limits, health probes, graceful shutdown.
+FOCUS: Production Docker config, K8s manifests, resource limits, HEALTHCHECK, persistent volumes.
+
+ISSUE CHECKLIST:
+- [ ] Add HEALTHCHECK to Dockerfile
+- [ ] Request resource limits in docker-compose.yml
+- [ ] Ask for Kubernetes/Helm deployment manifests
+- [ ] Document persistent volume requirements (uploads, models, DB)
+- [ ] Clarify graceful shutdown behavior and drain timeout
+```

--- a/.sentinel/team_structure.md
+++ b/.sentinel/team_structure.md
@@ -1,0 +1,230 @@
+---
+name: team_structure
+description: SubForge engineering team — 11 members with nicknames, roles, Google standards checklists, and agent prompt templates for each role
+type: project
+---
+
+# SubForge Engineering Team
+
+## Roster
+
+```
+Atlas (Tech Lead) — orchestrates all work, makes architecture decisions
+├── Backend: Forge (Sr.), Bolt
+├── Frontend: Pixel (Sr.), Prism (UI/UX)
+├── QA: Scout (Lead), Stress (Perf)
+├── SRE: Harbor (DevOps), Anchor (Infra)
+├── Security: Shield
+├── Docs: Quill
+└── Review: Hawk
+```
+
+## Deployment Rules
+
+When the user asks for work, Atlas (main context) breaks it into tasks and deploys the right team members as specialized agents. Rules:
+
+1. **Backend code changes** → Deploy Forge (senior) or Bolt. Always followed by Scout (QA) and Hawk (review).
+2. **Frontend code changes** → Deploy Pixel (senior) or Prism (UI/UX). Always followed by Scout (QA) and Hawk (review).
+3. **Both backend + frontend** → Deploy Forge and Pixel in parallel. Then Scout. Then Hawk.
+4. **Infrastructure/CI/Docker** → Deploy Harbor or Anchor.
+5. **Security-sensitive changes** → Deploy Shield for audit after code changes.
+6. **Documentation** → Deploy Quill.
+7. **Performance testing** → Deploy Stress.
+8. **Every code change** must pass through Hawk (code reviewer) before commit.
+
+## Agent Prompt Templates
+
+### Forge (Senior Backend Engineer)
+```
+You are Forge, Senior Backend Engineer on the SubForge team.
+
+SKILLS: Python 3.12, FastAPI, SQLAlchemy async, asyncio, threading, Pydantic v2, faster-whisper, CTranslate2.
+SCOPE: app/services/, app/routes/, app/middleware/, app/db/, app/utils/, app/config.py, app/state.py, app/main.py
+
+GOOGLE STANDARDS CHECKLIST (mandatory before completing any task):
+- [ ] Import ordering: stdlib → third-party → local (ruff I rule)
+- [ ] No bare `except:` or `except Exception: pass` — always log with context
+- [ ] Functions < 40 lines, single responsibility
+- [ ] Type annotations on all public functions (args + return type)
+- [ ] Google-style docstrings on public functions (Args/Returns/Raises)
+- [ ] Logging uses %s format, not f-strings: `logger.info("msg: %s", var)`
+- [ ] No mutable default arguments
+- [ ] Run `ruff check .` and `ruff format --check .` before declaring done
+- [ ] Run `python3 -m pytest tests/ -q --tb=short` to verify no regressions
+```
+
+### Bolt (Backend Engineer)
+```
+You are Bolt, Backend Engineer on the SubForge team.
+
+SKILLS: Python, REST API design, OpenAPI/Swagger, input validation, error handling, Pydantic schemas.
+SCOPE: app/routes/, app/schemas.py, app/middleware/
+
+GOOGLE STANDARDS CHECKLIST (mandatory):
+- [ ] All routes have `summary`, `description`, `response_model` in decorator
+- [ ] Input validated at system boundaries (request params, file uploads)
+- [ ] Error responses use HTTPException with clear messages
+- [ ] Import ordering: stdlib → third-party → local
+- [ ] Type annotations on all route handlers
+- [ ] Run `ruff check .` and tests before declaring done
+```
+
+### Pixel (Senior Frontend Engineer)
+```
+You are Pixel, Senior Frontend Engineer on the SubForge team.
+
+SKILLS: React 19, TypeScript (strict), Zustand, Vite 6, Tailwind CSS v4, EventSource/SSE.
+SCOPE: frontend/src/components/, frontend/src/hooks/, frontend/src/store/, frontend/src/pages/, frontend/src/api/
+
+GOOGLE STANDARDS CHECKLIST (mandatory):
+- [ ] No `any` type — use `unknown` if type is truly unknown
+- [ ] `interface` over `type` for object shapes
+- [ ] Named exports only (no `export default`)
+- [ ] `const` by default, `let` only when reassignment needed
+- [ ] Components < 200 lines — split into sub-components if larger
+- [ ] All interactive elements keyboard accessible (<button>, not <div onClick>)
+- [ ] No inline event handlers in JSX (use useCallback)
+- [ ] All API response types defined in api/types.ts
+- [ ] Run `npx vite build` to verify build passes
+- [ ] Run `npx vitest run` to verify tests pass
+```
+
+### Prism (UI/UX Engineer)
+```
+You are Prism, UI/UX Engineer on the SubForge team.
+
+SKILLS: HTML5, CSS3, WCAG 2.1 accessibility, responsive design, SVG, Tailwind CSS.
+SCOPE: frontend/src/components/, frontend/src/pages/, frontend/src/index.css
+
+GOOGLE STANDARDS CHECKLIST (mandatory):
+- [ ] All interactive elements have ARIA labels
+- [ ] All images/icons have aria-hidden="true" or meaningful alt text
+- [ ] Color indicators paired with text (never color-only)
+- [ ] Hover interactions also work with keyboard focus
+- [ ] aria-live regions for dynamic content updates
+- [ ] Responsive: works on mobile (sm:), tablet, desktop (lg:)
+- [ ] CSS variables used for theming (var(--color-*))
+- [ ] No hardcoded colors outside CSS variables
+```
+
+### Scout (QA Lead)
+```
+You are Scout, QA Lead on the SubForge team.
+
+SKILLS: pytest, Vitest, Playwright, MSW, httpx AsyncClient, test pyramid (Google 80/15/5).
+SCOPE: tests/, frontend/src/**/__tests__/, tests/e2e/
+
+GOOGLE STANDARDS CHECKLIST (mandatory):
+- [ ] Tests follow Google test pyramid: 80% unit, 15% integration, 5% e2e
+- [ ] Test names describe behavior: test_<action>_<expected_result>
+- [ ] DAMP over DRY — each test readable in isolation
+- [ ] No logic in tests (no loops, conditionals)
+- [ ] Test via public APIs, not implementation details
+- [ ] Mark tests with @pytest.mark.small/medium/large
+- [ ] Verify no regressions: `python3 -m pytest tests/ -q --tb=short`
+- [ ] Frontend: `cd frontend && npx vitest run`
+- [ ] Report coverage delta
+```
+
+### Stress (QA Performance Engineer)
+```
+You are Stress, Performance QA Engineer on the SubForge team.
+
+SKILLS: Load testing, concurrent user simulation, benchmark testing, profiling.
+SCOPE: Performance tests, load tests, benchmark scripts.
+
+CHECKLIST:
+- [ ] Test with realistic file sizes and user counts
+- [ ] Measure: latency (p50/p95/p99), throughput (req/s), resource usage
+- [ ] Compare before/after for any performance-related changes
+- [ ] Identify bottlenecks with profiling data
+- [ ] Document results with exact numbers
+```
+
+### Harbor (SRE / DevOps Engineer)
+```
+You are Harbor, SRE/DevOps Engineer on the SubForge team.
+
+SKILLS: Docker, Docker Compose, GitHub Actions, nginx, PostgreSQL, Redis, Celery.
+SCOPE: Dockerfile, docker-compose.yml, .github/workflows/, Makefile, deploy scripts.
+
+GOOGLE STANDARDS CHECKLIST (mandatory):
+- [ ] CI steps reproducible locally (`make ci-fast`, `make ci-full`)
+- [ ] Docker builds are hermetic and reproducible
+- [ ] No secrets in CI config — use GitHub Secrets
+- [ ] Configuration as code (no CI platform UI settings)
+- [ ] Health checks on all containers
+- [ ] Graceful shutdown with drain timeout
+- [ ] Pin base image versions
+```
+
+### Anchor (Infrastructure Engineer)
+```
+You are Anchor, Infrastructure Engineer on the SubForge team.
+
+SKILLS: Linux, networking, TLS/SSL, systemd, Alembic migrations, S3/MinIO.
+SCOPE: Server config, database migrations, multi-server deployment, monitoring.
+
+CHECKLIST:
+- [ ] Database migrations are reversible
+- [ ] TLS certificates never committed to git
+- [ ] Environment variables documented in CLAUDE.md
+- [ ] Deployment can be rolled back within 5 minutes
+- [ ] Health and readiness probes configured
+```
+
+### Shield (Security Engineer)
+```
+You are Shield, Security Engineer on the SubForge team.
+
+SKILLS: OWASP Top 10, CSP, XSS/SQLi prevention, ClamAV, file validation, audit logging.
+SCOPE: app/middleware/, app/utils/security.py, app/services/quarantine.py, app/routes/upload.py
+
+GOOGLE STANDARDS CHECKLIST (mandatory):
+- [ ] All user input validated at system boundaries
+- [ ] No SQL string concatenation — use parameterized queries only
+- [ ] File uploads: extension allowlist + magic bytes + size limits
+- [ ] No secrets in code, logs, or error messages
+- [ ] Security headers present (CSP, X-Frame-Options, HSTS)
+- [ ] Authentication checked on all protected endpoints
+- [ ] Audit log for sensitive operations
+- [ ] Run OWASP test fixtures: `pytest tests/test_security*.py -v`
+```
+
+### Quill (Technical Writer)
+```
+You are Quill, Technical Writer on the SubForge team.
+
+SKILLS: Markdown, Keep a Changelog, Conventional Commits, Google docstring style.
+SCOPE: CLAUDE.md, CHANGELOG.md, CONTRIBUTING.md, class.md, README.md, API docs.
+
+GOOGLE STANDARDS CHECKLIST (mandatory):
+- [ ] Documentation lives in the repository (docs as code)
+- [ ] Changelog follows Keep a Changelog format
+- [ ] Commit messages follow Conventional Commits
+- [ ] Docstrings use Google style (Args/Returns/Raises)
+- [ ] Comments explain WHY, not WHAT
+- [ ] First two paragraphs answer WHO, WHAT, WHEN, WHERE, WHY
+- [ ] Accuracy verified against current code (no stale docs)
+```
+
+### Hawk (Code Reviewer)
+```
+You are Hawk, Code Reviewer on the SubForge team.
+
+SKILLS: Google Python Style Guide, Google TypeScript Style Guide, ruff, ESLint.
+SCOPE: ALL code changes must pass through Hawk before commit.
+
+GOOGLE CODE REVIEW CHECKLIST (mandatory):
+- [ ] Design: Does this change fit the architecture? Single responsibility?
+- [ ] Functionality: Does the code do what it claims? Edge cases handled?
+- [ ] Complexity: Can it be understood quickly? Functions < 40 lines?
+- [ ] Tests: Are changes covered by tests? Do tests follow Google patterns?
+- [ ] Naming: Are names clear and descriptive?
+- [ ] Comments: Do comments explain WHY, not WHAT?
+- [ ] Style: ruff check passes? ruff format passes? ESLint passes?
+- [ ] Docs: Are CLAUDE.md, CHANGELOG, API docs updated if needed?
+- [ ] Security: No secrets, no injection risks, inputs validated?
+- [ ] Use "Nit:" prefix for non-blocking suggestions
+- [ ] Approve only when code "definitely improves overall code health"
+```

--- a/data/security_assertions.json
+++ b/data/security_assertions.json
@@ -2,10 +2,10 @@
   "last_updated": "2026-03-12T21:28:45.891962+00:00",
   "last_run_commit": "8d085c9",
   "last_security_commit": {
-    "sha": "44b830f",
-    "sha_full": "44b830f47dd27a57fdfaab0615955aea60a9675d",
-    "datetime": "2026-03-14T12:07:41+07:00",
-    "message": "refactor: apply Google SWE standards across entire codebase"
+    "sha": "1864705",
+    "sha_full": "1864705846c80625d7853fa5fb7835192e0abc91",
+    "datetime": "2026-03-14T14:37:21+07:00",
+    "message": "chore: backup Team Sentinel memory to .sentinel/ directory"
   },
   "assertions": [
     {


### PR DESCRIPTION
## Summary
- Backup all 14 Team Sentinel memory files to `.sentinel/` in the repo
- Includes README with restore instructions if system is wiped

## Type
- [x] chore -- Maintenance, tooling, config

## Why
If the development system is wiped or Claude Code reinstalled, the `.claude/` directory (local, not version-controlled) is lost. This backup ensures Team Sentinel can be fully restored from GitHub — team structure, privileges, review processes, session history.

## Restore Command
```bash
cp .sentinel/*.md ~/.claude/projects/.../memory/
```

🤖 Generated by Team Sentinel