### PR TITLE
docs(config): fix .sentinel restore path and explain naming pattern

### DIFF
--- a/.sentinel/README.md
+++ b/.sentinel/README.md
@@ -12,11 +12,15 @@ If starting fresh on a new system:
 
 ```bash
 # After installing Claude Code and cloning the repo:
-mkdir -p ~/.claude/projects/-home-claude-user-subtitle-generator/memory/
-cp .sentinel/*.md ~/.claude/projects/-home-claude-user-subtitle-generator/memory/
+# The memory path is derived from your working directory, with slashes replaced by dashes.
+# For /root/subtitle-generator the path is:
+mkdir -p ~/.claude/projects/-root-subtitle-generator/memory/
+cp .sentinel/*.md ~/.claude/projects/-root-subtitle-generator/memory/
 ```
 
-Adjust the path if your working directory differs from `/home/claude-user/subtitle-generator/`.
+The memory path pattern is `~/.claude/projects/<working-dir-with-dashes>/memory/`, where the working directory's `/` separators are replaced with `-`. For example:
+- `/root/subtitle-generator` → `-root-subtitle-generator`
+- `/home/claude-user/subtitle-generator` → `-home-claude-user-subtitle-generator`
 
 ## Contents
 
@@ -42,7 +46,7 @@ Adjust the path if your working directory differs from `/home/claude-user/subtit
 When memory files are updated in `.claude/`, copy them here and commit:
 
 ```bash
-cp ~/.claude/projects/-home-claude-user-subtitle-generator/memory/*.md .sentinel/
+cp ~/.claude/projects/-root-subtitle-generator/memory/*.md .sentinel/
 git add .sentinel/ && git commit -m "chore: sync .sentinel/ backup with latest memory"
 ```
 


### PR DESCRIPTION
## Summary
- Fix restore command in `.sentinel/README.md` to use the correct path (`-root-subtitle-generator` instead of `-home-claude-user-subtitle-generator`)
- Add explanation of the path naming pattern so users can adapt for different working directories

## Type
- [x] docs -- Documentation only

## Why
The previous restore command used a placeholder path that didn't match the actual system, causing `cp` to fail with "not a directory".

🤖 Generated with [Claude Code](https://claude.com/claude-code)