### PR TITLE
fix(deploy): add complete .env.example and document Docker preview subdomain

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,43 +1,116 @@
 # ============================================================
-# Subtitle Generator - Environment Configuration
-# Copy this file to .env and adjust values for your deployment
+# Subtitle Generator — Environment Configuration
+# Copy this file to .env and fill in values for your deployment.
+# Lines starting with # are comments. Never commit your .env file.
 # ============================================================
 
-# --- Database ---
-# SQLite (default, good for single-machine):
+# ── Server ───────────────────────────────────────────────────
+# "dev" = plain HTTP on PORT (no HSTS, no redirect)
+# "prod" = HTTPS on 443, HTTP redirect on 80, HSTS enabled
+ENVIRONMENT=dev
+
+# Port for HTTP/dev mode (ignored when ENVIRONMENT=prod)
+PORT=8000
+
+# Server role: standalone (all-in-one), web (API only), worker (Celery only)
+ROLE=standalone
+
+# ── TLS (production only) ────────────────────────────────────
+# Required when ENVIRONMENT=prod. Paths inside the container.
+SSL_CERTFILE=
+SSL_KEYFILE=
+
+# ── Database ─────────────────────────────────────────────────
+# SQLite — default, good for single-machine deployments
 DATABASE_URL=sqlite+aiosqlite:///./subtitle_generator.db
-# PostgreSQL (production, via Docker Compose):
+# PostgreSQL — recommended for production / multi-server:
 # DATABASE_URL=postgresql+asyncpg://subtitle:subtitle@localhost:5432/subtitle_generator
 
-DB_POOL_SIZE=5              # Connection pool size (increase for multi-worker)
-DB_MAX_OVERFLOW=10          # Extra connections allowed beyond pool_size
-DB_POOL_RECYCLE=3600        # Recycle connections after N seconds
+DB_POOL_SIZE=5          # Connection pool size (increase for multi-worker)
+DB_MAX_OVERFLOW=10      # Extra connections allowed beyond pool_size
+DB_POOL_RECYCLE=3600    # Recycle connections after N seconds
 
-# --- Authentication ---
-# Comma-separated API keys. Leave empty to disable auth.
+# ── Redis ────────────────────────────────────────────────────
+# Required for: distributed mode, Celery workers, rate limiting, SSE relay
+# Leave empty to run without Redis (standalone mode only)
+REDIS_URL=
+# Example: REDIS_URL=redis://localhost:6379/0
+
+# ── Celery (distributed mode) ────────────────────────────────
+CELERY_BROKER_URL=
+# Example: CELERY_BROKER_URL=redis://localhost:6379/0
+
+# ── File Storage ─────────────────────────────────────────────
+# "local" = store uploads/outputs on disk (default)
+# "s3"    = store in S3-compatible object storage (requires S3_* vars)
+STORAGE_BACKEND=local
+
+S3_BUCKET=subtitles
+S3_ENDPOINT=
+# Example (MinIO): S3_ENDPOINT=http://localhost:9000
+
+S3_ACCESS_KEY=
+S3_SECRET_KEY=
+
+# ── MinIO (optional S3-compatible local storage) ─────────────
+MINIO_ROOT_USER=subtitle
+MINIO_ROOT_PASSWORD=subtitle_secret
+
+# ── Authentication ───────────────────────────────────────────
+# Comma-separated API keys. Leave empty to disable authentication.
 API_KEYS=
-# Example: API_KEYS=key1,key2,key3
+# Example: API_KEYS=key1abc,key2def,key3ghi
 
-# --- Hugging Face ---
-# Required for downloading whisper models (or use pre-cached models)
+# ── Hugging Face ─────────────────────────────────────────────
+# Required to download Whisper / pyannote models the first time.
 HF_TOKEN=
 
-# --- Model Preloading ---
-# Preload a whisper model at startup to avoid first-request latency
-# Options: tiny, base, small, medium, large (leave empty to skip)
+# ── Model Preloading ─────────────────────────────────────────
+# Preload a Whisper model at startup to avoid first-request latency.
+# Options: tiny | base | small | medium | large (leave empty to skip)
 PRELOAD_MODEL=
 
-# --- File Management ---
-FILE_RETENTION_HOURS=24     # Auto-delete uploaded/output files after N hours
+# ── Concurrency ──────────────────────────────────────────────
+# Max parallel transcription tasks. 0 = auto-tune at startup.
+MAX_CONCURRENT_TASKS=3
 
-# --- Performance ---
-ENABLE_COMPRESSION=true     # GZip response compression
-MAX_CONCURRENT_TASKS=3      # Max parallel transcription tasks (auto-tuned at startup)
+# ── File Retention ───────────────────────────────────────────
+# Auto-delete uploaded and output files after this many hours.
+FILE_RETENTION_HOURS=24
 
-# --- CORS ---
-# Comma-separated allowed origins. Use * for development only.
+# ── CORS ─────────────────────────────────────────────────────
+# Comma-separated allowed origins. Use * for local development only.
 CORS_ORIGINS=*
-# Production example: CORS_ORIGINS=https://yourdomain.com,https://app.yourdomain.com
+# Production example: CORS_ORIGINS=https://yourdomain.com,https://newui.yourdomain.com
 
-# --- Logging ---
-LOG_LEVEL=info              # debug, info, warning, error
+# ── Domain (nginx / docker-compose) ─────────────────────────
+# Your public domain name, used in nginx config and CORS_ORIGINS substitution.
+DOMAIN=yourdomain.com
+
+# ── Logging ──────────────────────────────────────────────────
+LOG_LEVEL=info          # debug | info | warning | error
+
+# ── Compression ──────────────────────────────────────────────
+ENABLE_COMPRESSION=true
+
+# ── Translation ──────────────────────────────────────────────
+# Segments per progress-update event during Argos Translate runs.
+TRANSLATION_BATCH_SIZE=50
+
+# ── Webhooks ─────────────────────────────────────────────────
+# Optional URL to POST alert payloads when tasks fail or system enters critical state.
+WEBHOOK_ALERT_URL=
+
+# ── GitHub Integration ───────────────────────────────────────
+# Optional: used for GitHub API calls (release notes, issue linking).
+GITHUB_TOKEN=
+
+# ── Flower (Celery dashboard) ────────────────────────────────
+# Basic-auth credentials for the Flower monitoring UI (port 5555).
+FLOWER_USER=admin
+FLOWER_PASSWORD=changeme
+
+# ── Production Image Tag ─────────────────────────────────────
+# The Docker image tag used by the cpu profile in docker-compose.yml.
+# Change this only after the new image has been reviewed and approved.
+PROD_IMAGE_TAG=v2.1.0

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -305,10 +305,16 @@ If you prefer full control:
 ```bash
 git clone https://github.com/volehuy1998/subtitle-generator /opt/subtitle-generator
 cd /opt/subtitle-generator
+
+# Copy and fill in the environment config file
+cp .env.example .env
+# Edit .env with your values — see comments inside for each variable
+nano .env
+
 python3 -m venv .venv
 .venv/bin/pip install -r requirements.txt
 
-# Dev:
+# Dev (reads .env automatically if python-dotenv is installed, or export vars):
 ENVIRONMENT=dev .venv/bin/python main.py
 
 # Prod (with certificates already in place):
@@ -316,6 +322,96 @@ ENVIRONMENT=prod \
 SSL_CERTFILE=/path/to/fullchain.pem \
 SSL_KEYFILE=/path/to/privkey.pem \
 .venv/bin/python main.py
+```
+
+See [`.env.example`](../.env.example) for the full list of configurable environment variables with descriptions and defaults.
+
+---
+
+## Docker: preview subdomain deployment (newui profile)
+
+The `newui` Docker Compose profile runs the current codebase build on an internal port (`127.0.0.1:8001`), allowing an external nginx reverse proxy to serve it at a separate subdomain (e.g. `newui.example.com`) for design review before promoting to production.
+
+**This is required for any frontend design changes.** See [CONTRIBUTING.md §6a](../CONTRIBUTING.md#6a-ui--frontend-design-review-process) for the full subdomain-first design review policy.
+
+```bash
+# Start the preview container (builds from current code)
+docker compose --profile newui up -d --build
+
+# Verify it is running on port 8001
+curl -s http://127.0.0.1:8001/api/health | head -c 100
+```
+
+### Host nginx config (two-domain setup)
+
+A minimal nginx config that routes both the production domain and the preview subdomain:
+
+```nginx
+# /etc/nginx/sites-available/subforge
+
+# HTTP → HTTPS redirect for both domains
+server {
+    listen 80;
+    server_name example.com newui.example.com;
+    return 301 https://$host$request_uri;
+}
+
+# Production domain → production container (pinned image)
+server {
+    listen 443 ssl;
+    server_name example.com;
+
+    ssl_certificate     /etc/letsencrypt/live/example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/example.com/privkey.pem;
+
+    location / {
+        proxy_pass         https://127.0.0.1:8000;
+        proxy_ssl_verify   off;
+        proxy_set_header   Host $host;
+        proxy_set_header   X-Real-IP $remote_addr;
+        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto https;
+        # SSE support
+        proxy_buffering    off;
+        proxy_read_timeout 3600s;
+    }
+}
+
+# Preview subdomain → preview container (current build)
+server {
+    listen 443 ssl;
+    server_name newui.example.com;
+
+    ssl_certificate     /etc/letsencrypt/live/newui.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/newui.example.com/privkey.pem;
+
+    location / {
+        proxy_pass         http://127.0.0.1:8001;
+        proxy_set_header   Host $host;
+        proxy_set_header   X-Real-IP $remote_addr;
+        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto https;
+        # SSE support
+        proxy_buffering    off;
+        proxy_read_timeout 3600s;
+    }
+}
+```
+
+### Promoting a reviewed design to production
+
+After investor approval:
+
+```bash
+# 1. Build and tag the new production image
+docker build -t subtitle-generator-prod:v2.2.0 .
+
+# 2. Update PROD_IMAGE_TAG in .env
+#    (do NOT hardcode it in docker-compose.yml)
+sed -i 's/^PROD_IMAGE_TAG=.*/PROD_IMAGE_TAG=v2.2.0/' .env
+
+# 3. Restart the production container
+docker compose --profile cpu up -d
 ```
 
 See `CLAUDE.md` for the full environment variable reference and architecture details.


### PR DESCRIPTION
## Author
**Name:** Sentinel Team Leader
**Role:** Lead Engineer, Team Sentinel
**Team:** SubForge Engineering (Sentinel)

## Summary
- Expanded `.env.example` to cover all 30+ environment variables with inline documentation — was previously missing `DOMAIN`, `REDIS_URL`, `CELERY_*`, `S3_*`, `MINIO_*`, `FLOWER_*`, `WEBHOOK_ALERT_URL`, `PROD_IMAGE_TAG`, `TRANSLATION_BATCH_SIZE`, and others
- Updated `docs/DEPLOY.md` manual installation section to guide users through `cp .env.example .env` before starting
- Added Docker preview subdomain section to `DEPLOY.md`: `newui` profile usage, nginx two-domain config template, and production promotion checklist

## Type
- [x] fix -- Bug fix
- [x] docs -- Documentation only

## Changes
- `.env.example` — expanded from 12 to 30+ documented variables
- `docs/DEPLOY.md` — added `.env.example` reference and newui preview subdomain deployment guide

## Test Plan
- [x] Manual review of `.env.example` — all variables match `CLAUDE.md` reference and `app/config.py`
- [x] Manual review of `DEPLOY.md` — nginx config matches working host config

Closes #47