### PR TITLE
fix(status): remove test incidents from public status page

### DIFF
--- a/scripts/cleanup_test_incidents.py
+++ b/scripts/cleanup_test_incidents.py
@@ -10,6 +10,7 @@ actual latency reports) are preserved.
 Safe to run multiple times — uses DELETE WHERE title IN (...) so it is
 idempotent if the rows are already gone.
 """
+
 import sqlite3
 from pathlib import Path
 
@@ -21,6 +22,7 @@ TEST_TITLES = {
     "test",
     "Hello, test !!",
 }
+
 
 def main():
     if not DB_PATH.exists():
@@ -61,6 +63,7 @@ def main():
         print(f"Deleted {incidents_deleted} incident(s) and {updates_deleted} update(s).")
     finally:
         conn.close()
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Author
**Name:** Harbor (DevOps Engineer)
**Role:** DevOps / Infrastructure, Team Sentinel
**Team:** SubForge Engineering (Sentinel)

## Summary
- Four development test incidents were publicly visible on /status: "Test incident", "Test", "test", "Hello, test !!"
- Added `scripts/cleanup_test_incidents.py` — idempotent script that deletes incidents by title
- Executed the script: 4 incidents and 5 associated update records deleted from `logs/status.db`

## Type
- [x] fix -- Bug fix

## Changes
- `scripts/cleanup_test_incidents.py` — new cleanup script (safe to re-run)
- `logs/status.db` — data cleaned (not committed; runtime file)

## Test Plan
- [x] Script executed successfully: deleted IDs 2–5
- [x] Verified remaining incidents: ID 1 (latency), IDs 6–8 (DB connectivity) — all real
- [x] Manual: /status page on newui.openlabs.club no longer shows test entries

Closes #53