### PR TITLE
fix(ui): hide GPU/CPU hardware badge on non-app pages

### DIFF
--- a/frontend/src/components/layout/AppHeader.tsx
+++ b/frontend/src/components/layout/AppHeader.tsx
@@ -143,8 +143,8 @@ export function AppHeader() {
       {/* Spacer */}
       <div className="flex-1" />
 
-      {/* GPU/CPU badge */}
-      {health !== null && (
+      {/* GPU/CPU badge — only relevant on the App page */}
+      {health !== null && window.location.pathname === '/' && (
         <div
           className="flex items-center gap-1.5 px-2.5 py-1 rounded-md mr-2"
           style={{


### PR DESCRIPTION
## Author
**Name:** Pixel (Frontend Engineer)
**Role:** Frontend Engineer, Team Sentinel
**Team:** SubForge Engineering (Sentinel)

## Summary
- The "No GPU" / "GPU" hardware badge was showing on About, Contact, Security, and Status pages where it provides no value to visitors
- Changed render condition in `AppHeader.tsx` to only show the badge when `window.location.pathname === '/'`
- Health dot (Healthy/Degraded/Error) and load bar remain visible on all pages

## Type
- [x] fix -- Bug fix

## Changes
- `frontend/src/components/layout/AppHeader.tsx` — one condition added to GPU badge render

## Test Plan
- [x] Frontend builds (`npm run build`) — clean
- [x] ESLint passes
- [x] Manual: GPU badge hidden on /about, /contact, /security, /status
- [x] Manual: GPU badge visible on /

Closes #54