### PR TITLE
ci: fix release-please — remove invalid package-name input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,6 @@ jobs:
         id: release
         with:
           release-type: python
-          package-name: subforge
 
   # Build and push Docker image on new release
   docker:


### PR DESCRIPTION
## Author
**Name:** Atlas
**Role:** Team Lead
**Team:** Team Sentinel

## Summary

The Release workflow has been failing on every push to main since PR #41 added release-please automation. Two root causes identified and fixed:

### Root Cause 1 — Invalid `package-name` input

`release-please-action@v4` removed the `package-name` input (it was a v3 parameter). The workflow was passing it, causing:

```
Unexpected input(s) 'package-name', valid inputs are ['token', 'release-type', ...]
```

**Fix:** Remove `package-name: subforge` from the action's `with:` block.

### Root Cause 2 — Insufficient workflow permissions

The repository's default workflow permissions were set to `read`, preventing the action from creating pull requests. Release-please needs to open a version-bump PR automatically.

**Fix:** Updated repository Actions settings to `write` permissions with PR creation enabled (via GitHub API — `default_workflow_permissions: write`, `can_approve_pull_request_reviews: true`).

## Files Changed

- `.github/workflows/release.yml` — removed `package-name: subforge`

## Test Plan

- [ ] CI passes on this PR
- [ ] After merge, verify Release workflow runs without error on next push to main
- [ ] Verify release-please can create its automated version PR

Closes #none (CI operational issue — no tracking issue was filed)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>