### PR TITLE
fix(config): bump PROD_IMAGE_TAG to v2.2.0 in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -113,4 +113,4 @@ FLOWER_PASSWORD=changeme
 # ── Production Image Tag ─────────────────────────────────────
 # The Docker image tag used by the cpu profile in docker-compose.yml.
 # Change this only after the new image has been reviewed and approved.
-PROD_IMAGE_TAG=v2.1.0
+PROD_IMAGE_TAG=v2.2.0


### PR DESCRIPTION
## Summary

- Updates `.env.example` `PROD_IMAGE_TAG` from `v2.1.0` to `v2.2.0` so operators who copy the example file after the v2.2.0 release will pin to the correct image

## Type
- [x] fix -- Bug fix

## Changes
- `.env.example` — `PROD_IMAGE_TAG=v2.1.0` → `v2.2.0`

## Test Plan
- [ ] `.env.example` diff is exactly one line

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)