### PR TITLE
chore: sync .sentinel/ memory — session 2026-03-15 complete

### DIFF
--- a/.sentinel/MEMORY.md
+++ b/.sentinel/MEMORY.md
@@ -15,5 +15,5 @@
 - [project_status_page.md](project_status_page.md) — Public status page at /status with auto-incident detection
 - [project_session_20260314.md](project_session_20260314.md) — Major session: UI overhaul, Google SWE standards, Team Sentinel, 17 issues resolved, 10 PRs merged, CodeQL enabled
 - [project_ci_failures.md](project_ci_failures.md) — CI fully green as of 2026-03-15; ESLint mask removed (PR #65), all errors fixed
-- [project_pending_work.md](project_pending_work.md) — Open: distributed deploy, process_video refactor, SLOs, mypy, Team Meridian #37
-- [project_session_20260315.md](project_session_20260315.md) — Session 2026-03-15: CI/CD fixes (PRs #63/#65), subdomain evaluation, PR attribute standards
+- [project_pending_work.md](project_pending_work.md) — Open: PR #81 (release-please), distributed deploy, process_video refactor, SLOs, mypy
+- [project_session_20260315.md](project_session_20260315.md) — Session 2026-03-15 (full day): ESLint fix, Meridian issues #67–72, v2.2.0 release, cross-team automation (PRs #79/#80/#83), all resolved

--- a/.sentinel/project_pending_work.md
+++ b/.sentinel/project_pending_work.md
@@ -4,25 +4,28 @@ description: Open work items as of 2026-03-15
 type: project
 ---
 
-As of 2026-03-15, CI is fully green. All known ESLint errors resolved.
+As of 2026-03-15, all open PRs resolved. CI fully green.
 
-## Recently completed (2026-03-15)
+## Completed this session (2026-03-15)
 
-- **release-please automation** — PR #63 merged
-- **ESLint mask removed** — PR #65 merged: removed `|| true` from CI, fixed all 5 hidden ESLint errors
-- **Team Meridian issues #67–#72** — all resolved and merged (PRs #68–#74)
-- **release-please / v2.2.0** — PR #64 merged; Docker image published; PR #76 merged (.env.example PROD_IMAGE_TAG bump)
-- **PR #80 merged** — Quill's Configuration Best Practices section in DEPLOY.md (resolves Issue #78)
-- **RFC #82 + PR #83** — Cross-team automation (CODEOWNERS + release-notify.yml + deploy-validate CI job + CONTRIBUTING.md §10). PR #83 open, awaiting Meridian review (48h SLA).
+- **PR #80 MERGED** — Quill's Configuration Best Practices in DEPLOY.md (resolves #78)
+- **PR #83 MERGED** — Cross-team automation (CODEOWNERS + release-notify.yml + deploy-validate CI + CONTRIBUTING.md §10). Reviewed and approved by both Sentinel and Meridian teams.
+- **PR #79 MERGED** — Team Meridian .meridian/ memory backup. Three rounds of security review; public IP redacted from MEMORY.md index before merge.
+- **Issue #82 CLOSED** — RFC resolved by PR #83
 
 ## Open items
 
-- **PR #83** — Cross-team automation (CODEOWNERS, release-notify.yml, deploy-validate); awaiting Meridian review (due ~2026-03-16T20:40)
-- **PR #79** — Team Meridian .meridian/ memory backup; blocked on Meridian redacting public IP + open DB ports from meridian_server.md
-- **PR #81** — release-please 2.2.1 PR (auto-generated); will auto-merge when next feature lands
+- **PR #81** — release-please 2.3.0 (auto-generated after PR #83 feat merged). Will auto-merge when enough features land. No action needed.
+- **Forge's future note** — CODEOWNERS should migrate from `@volehuy15061998` (individual) to GitHub org team when Meridian grows
 - **Distributed system deployment** — 5-server plan (sub-ctrl, sub-api-1/2, sub-data, sub-worker-1) not yet started
 - **process_video() refactoring** — 514 lines → step functions, deferred
 - **SLOs** — not yet defined
 - **mypy/pyright** — not yet in CI
+
+## Cross-team automation now in place
+
+- CODEOWNERS: 8 deploy-critical files require Meridian co-review (48h SLA)
+- release-notify.yml: joint deployment checklist issue on every release
+- ci.yml deploy-validate: compose config, bash syntax, PROD_IMAGE_TAG consistency
+- 3 new labels: deployment, sentinel, meridian
 </content>
-</invoke>

--- a/.sentinel/project_session_20260315.md
+++ b/.sentinel/project_session_20260315.md
@@ -1,43 +1,37 @@
 ---
 name: project_session_20260315
-description: Session on 2026-03-15 — CI/CD fixes, ESLint mask removed, subdomain UI evaluation, PR attribute standards enforced
+description: Session 2026-03-15 summary — cross-team automation, PR closures, all issues resolved
 type: project
 ---
 
-# Session Summary — 2026-03-15
+## Session summary — 2026-03-15
 
-## What Was Done
+### Completed
 
-### CI/CD Fixes (PRs #63, #65)
+1. **PR #65** — ESLint fix (eslint-disable-next-line on wrong line in StatusPage.tsx)
+2. **Meridian Issues #67–#72** — all resolved: deploy.sh syntax, docker-compose newui profile, nginx proxy_pass docs, session cookie Secure flag, CORS explicit headers, CONTRIBUTING.md onboarding
+3. **v2.2.0 release** — PR #64 merged (CHANGELOG + version bump), Docker image published, PR #76 merged (.env.example PROD_IMAGE_TAG)
+4. **PR #80 merged** — Configuration Best Practices in DEPLOY.md (resolves Meridian issue #78)
+5. **RFC #82** — Proposed automated cross-team collaboration; Team Meridian agreed on Option D
+6. **PR #83 merged** — CODEOWNERS + release-notify.yml + deploy-validate CI job + CONTRIBUTING.md §10. Joint approval from Sentinel (Bolt, Forge, Scout, Atlas) and Meridian (Compass, Crane, Gauge, Signal).
+7. **PR #79 merged** — Team Meridian .meridian/ memory backup. Three security review rounds; IP/port redaction required and completed.
 
-**PR #63 — release-please fix (merged)**
-- `release-please-action@v4` was failing: `package-name` input is v3 syntax, invalid in v4
-- `default_workflow_permissions` was `read` — blocked PR creation by release-please
-- Fix: removed `package-name` from `.github/workflows/release.yml`, set permissions to `write` via API
-- First green Release workflow run achieved
+### Key agreements with Team Meridian
 
-**PR #65 — ESLint mask removed + 5 errors fixed (merged)**
-- `|| true` in CI ESLint step was silently swallowing all linting failures
-- 5 real ESLint errors uncovered and fixed:
-  1. `react-refresh/only-export-components` → extracted `Router` into `src/Router.tsx`
-  2. `react-hooks/static-components` → direct conditional returns in `Router.tsx`
-  3. TDZ circular reference in `useSSE.ts` → added `connectRef` ref
-  4. `@typescript-eslint/no-unused-expressions` in `StatusPage.tsx toggleCommit` → if/else
-  5. `react-hooks/set-state-in-effect` in `StatusPage.tsx useEffect` → moved disable comment to correct line
-- Issue #66 created to track the ESLint mask bug
+- 48h review SLA for CODEOWNERS-triggered reviews
+- 8 deploy-critical files require Meridian co-review
+- Joint deployment checklist issue auto-created on every release
+- CI validates compose profiles, bash syntax, tag consistency on every PR
 
-### Subdomain UI Evaluation (Enterprise Slate)
-- Playwright screenshots of all 5 pages at `newui.openlabs.club`
-- Found and fixed: Google Fonts blocked (CSP `connect-src` → `font-src`), GPU badge on all pages, outdated About stack, wrong security commit SHA
-- PRs #57–61 merged; Docker image rebuilt on port 8001; re-verified clean
+### Infrastructure added
 
-### PR Attribute Standards Enforced
-- All PRs must have 6 GitHub attributes: Reviewers, Assignees, Labels, Projects, Milestone, Development
-- **Reviewer limitation**: GitHub prevents author from reviewing their own PR; `volehuy1998` is the only collaborator — this is a solo repo constraint
-- Projects linked to "SubForge Roadmap" (PVT_kwHOAi6TKc4BRufS)
-- Milestone: v2.2.0 — UI & Developer Experience (ID 1) or v3.0.0 — Distributed System & Scale (ID 2)
+- .github/workflows/release-notify.yml — release deployment notifications
+- .github/CODEOWNERS — Meridian co-review for deploy-critical files
+- .meridian/ — Team Meridian memory backup directory
+- Labels: deployment, sentinel, meridian
+- CONTRIBUTING.md §10 — cross-team review protocol
 
-## Open Items (carried forward)
-- Distributed system deployment (5-server Ansible)
-- Team Meridian issue #37 (production deployment docs)
-- process_video() refactor, SLOs, mypy/pyright
+### How to apply
+
+When working on deploy-critical files, expect Meridian review to be required.
+On every release, a joint checklist issue will be auto-created.


### PR DESCRIPTION
Syncs Atlas's persistent memory to .sentinel/ after the full 2026-03-15 session.

**Updated files:**
- `project_pending_work.md` — reflects all PRs merged (#79, #80, #83), open items (PR #81, distributed deploy, SLOs, mypy)
- `project_session_20260315.md` — full session summary: ESLint fix, Meridian issues #67–72, v2.2.0 release, cross-team automation
- `MEMORY.md` — updated index descriptions

**Filed by:** Atlas (Sentinel Lead, Team Sentinel)
🤖 Generated with [Claude Code](https://claude.com/claude-code)