### PR TITLE
chore: sync .meridian/ + add automated backup script

### DIFF
--- a/.meridian/MEMORY.md
+++ b/.meridian/MEMORY.md
@@ -18,6 +18,7 @@
 - [feedback_delegate_no_bottleneck.md](feedback_delegate_no_bottleneck.md) — Compass must delegate to specialists, never bottleneck tasks at leader level
 - [feedback_author_disclosure.md](feedback_author_disclosure.md) — Every team member must disclose their identity (name, role) when creating any content
 - [feedback_vault_review_before_push.md](feedback_vault_review_before_push.md) — Vault must scan every .meridian/ sync for sensitive data before pushing to GitHub
+- [feedback_always_backup.md](feedback_always_backup.md) — CRITICAL: every memory change must be immediately backed up to GitHub via scripts/meridian-backup.sh
 
 ## Cross-Team Agreements
 - [project_cross_team_agreement.md](project_cross_team_agreement.md) — CODEOWNERS, 48h SLA, release notifications, CI validation — agreed 2026-03-15 via RFC #82

--- a/.meridian/feedback_always_backup.md
+++ b/.meridian/feedback_always_backup.md
@@ -1,0 +1,20 @@
+---
+name: feedback_always_backup
+description: CRITICAL investor rule — every memory change MUST be immediately backed up to GitHub via scripts/meridian-backup.sh. No exceptions.
+type: feedback
+---
+
+Every memory change MUST be immediately backed up to GitHub. This is non-negotiable.
+
+**Why:** The investor has repeated this instruction multiple times because Compass kept updating local memory without syncing to `.meridian/` on GitHub. This is the single most frequently violated rule. The investor should never have to remind us of this again.
+
+**How to apply:**
+1. After ANY write to `~/.claude/projects/-root-subtitle-generator/memory/`, immediately run:
+   ```bash
+   bash scripts/meridian-backup.sh
+   ```
+2. The script handles: file sync, Vault security scan, branch creation, commit, and push
+3. After the script runs, create a PR for the branch
+4. This applies to ALL memory updates — session logs, feedback rules, issue trackers, agreements, everything
+5. NEVER say "context saved" or "memory updated" without also having pushed to GitHub
+6. If in doubt, run the backup script — it's idempotent and will exit cleanly if nothing changed

--- a/.meridian/meridian_issues_tracker.md
+++ b/.meridian/meridian_issues_tracker.md
@@ -1,32 +1,42 @@
 ---
 name: meridian_issues_tracker
-description: Team Meridian filed issues tracker — all 7 deployment issues resolved by Sentinel, cross-team RFC agreed
+description: Team Meridian — all 7 issues resolved, 3 PRs authored, 3 PRs reviewed, 2 RFCs resolved
 type: project
 ---
 
-# Meridian Issues Tracker
+# Meridian Activity Tracker
 
-## Filed Issues — All Resolved
+## Issues Filed — All 7 Resolved
 
 | Issue | Title | Priority | Specialist | Resolution |
 |-------|-------|----------|-----------|------------|
-| [#67](https://github.com/volehuy1998/subtitle-generator/issues/67) | deploy.sh Unicode crash | P0-critical | Dockhand | PR #73 merged |
-| [#68](https://github.com/volehuy1998/subtitle-generator/issues/68) | Missing newui Docker profile | P1-high | Dockhand | PR #73 merged |
-| [#69](https://github.com/volehuy1998/subtitle-generator/issues/69) | ENVIRONMENT=prod redirect loop | P1-high | Crane | PR #73 merged |
-| [#70](https://github.com/volehuy1998/subtitle-generator/issues/70) | PROD_IMAGE_TAG not used | P0-critical | Dockhand | PR #73 merged |
-| [#71](https://github.com/volehuy1998/subtitle-generator/issues/71) | CLAUDE.md routes, WebSocket, cookie/CORS | P1-high | Signal + Vault | PR #73 + #74 merged |
-| [#72](https://github.com/volehuy1998/subtitle-generator/issues/72) | Missing collaborator onboarding | P2-medium | Compass | PR #73 merged |
-| [#78](https://github.com/volehuy1998/subtitle-generator/issues/78) | Config file best-practice docs | P2-medium | Compass | PR #80 merged |
+| #67 | deploy.sh Unicode crash | P0 | Dockhand | PR #73 |
+| #68 | Missing newui Docker profile | P1 | Dockhand | PR #73 |
+| #69 | ENVIRONMENT=prod redirect loop | P1 | Crane | PR #73 |
+| #70 | PROD_IMAGE_TAG not used | P0 | Dockhand | PR #73 |
+| #71 | CLAUDE.md routes, WebSocket, cookie/CORS | P1 | Signal+Vault | PR #73+#74 |
+| #72 | Missing collaborator onboarding | P2 | Compass | PR #73 |
+| #78 | Config best-practice docs | P2 | Compass | PR #80 |
 
-## PRs Authored/Reviewed
+## PRs Authored
 
-| PR | Title | Role | Status |
-|----|-------|------|--------|
-| #79 | .meridian/ memory backup | Author | Merged (3 review rounds) |
-| #83 | Cross-team automation | Reviewer | Merged |
+| PR | Title | Status |
+|----|-------|--------|
+| #79 | .meridian/ memory backup | Merged (3 review rounds) |
+| #85 | Memory sync (session complete) | Merged |
+| #91 | Final session sync | Open |
 
-## Cross-Team RFC
+## PRs Reviewed
 
-| RFC | Title | Status |
+| PR | Title | Specialists |
+|----|-------|-------------|
+| #83 | Cross-team automation | Crane, Gauge, Signal, Compass |
+| #86 | 30 CodeQL security fixes | Vault, Signal, Compass |
+| #87 | Automated sensitive data scanning | Vault, Compass |
+
+## RFCs Participated In
+
+| RFC | Topic | Status |
 |-----|-------|--------|
-| #82 | Automated cross-team collaboration | Agreed + Implemented (PR #83 merged) |
+| #82 | Cross-team automation | Agreed — PR #83 merged |
+| #89 | Sensitive data classification | Agreed — PR #87 updated |

--- a/.meridian/meridian_server_public.md
+++ b/.meridian/meridian_server_public.md
@@ -1,0 +1,59 @@
+---
+name: meridian_server
+description: Team Meridian server details — OS, hardware, domains, container layout (sensitive details redacted for public repo)
+type: reference
+---
+
+# Meridian Server Reference
+
+> **Note:** Sensitive infrastructure details (IP addresses, port bindings, absolute paths) are redacted in this public backup. The unredacted version is maintained in the local `.claude/projects/` memory only, accessible on the deployment server.
+
+## Server
+
+| Attribute | Value |
+|-----------|-------|
+| Public IP | `<server-ip>` |
+| OS | Ubuntu 22.04.5 LTS |
+| CPUs | 8 |
+| RAM | 15.6 GB |
+| Disk | 49 GB (44 GB free at deploy) |
+| GPU | None |
+
+## Domains
+
+| Domain | Purpose |
+|--------|---------|
+| meridian-openlabs.shop | Production (stable v2.1.0 UI) |
+| newui.meridian-openlabs.shop | Preview (current main build) |
+
+## TLS Certificates
+
+Both domains use Let's Encrypt certificates, auto-renewed via `certbot.timer`. A renewal hook reloads nginx after each renewal. Certificates expire 2026-06-12.
+
+## Container Layout
+
+| Container | Image | Binding | Profile |
+|-----------|-------|---------|---------|
+| postgres | postgres:16-alpine | localhost only | (always) |
+| redis | redis:7-alpine | localhost only | (always) |
+| subtitle-generator | subtitle-generator-prod:v2.1.0 | 127.0.0.1:8000 | cpu |
+| subtitle-generator-newui | built from current main | 127.0.0.1:8001 | newui |
+
+## Management Commands
+
+```bash
+# Logs
+docker compose --profile cpu --profile newui logs -f
+
+# Restart production
+docker compose --profile cpu restart
+
+# Restart preview
+docker compose --profile newui restart
+
+# Rebuild preview from latest code
+git pull && docker compose --profile newui up -d --build
+
+# Test cert renewal
+sudo certbot renew --dry-run
+```

--- a/.meridian/meridian_session_20260315.md
+++ b/.meridian/meridian_session_20260315.md
@@ -1,6 +1,6 @@
 ---
 name: meridian_session_20260315
-description: Full session context — deployment, 7 issues, audit, cross-team RFC, security PRs reviewed, sensitive data RFC, deployment updated
+description: Full session context — deployment, 7 issues, audit, cross-team RFC, security PRs reviewed, sensitive data RFC, deployment updated, all resolved
 type: project
 ---
 
@@ -8,42 +8,66 @@ type: project
 
 ## Final State
 
-All issues closed. All PRs merged. Deployment updated. Cross-team automation live.
+All issues closed. All PRs merged. Deployment updated. Cross-team automation live. Sensitive data scanning in CI.
 
 ### Deployment
 
 | Domain | Status | Image | Includes |
 |--------|--------|-------|----------|
-| meridian-openlabs.shop | Healthy | v2.1.0 pinned | Stable UI |
-| newui.meridian-openlabs.shop | Healthy | Latest main | Enterprise Slate + PR #86 security fixes + PR #87 secret scanning |
+| meridian-openlabs.shop | Healthy | v2.1.0 pinned | Stable purple UI (Inter font) |
+| newui.meridian-openlabs.shop | Healthy | Latest main | Enterprise Slate theme + all security fixes |
 
-### Merged PRs (this session)
+Infrastructure: PostgreSQL 16, Redis 7, host nginx (TLS + HSTS), Let's Encrypt (expires 2026-06-12)
+Config: `docker-compose.override.yml` (ports, no certs, ENVIRONMENT=dev) + `.env` (DOMAIN, PROD_IMAGE_TAG)
 
-| PR | Description | Meridian Role |
-|----|-------------|---------------|
-| #73 | deploy.sh fix, newui profile, PROD_IMAGE_TAG, docs | Issue reporter |
-| #74 | Cookie Secure flag, CORS headers | Issue reporter |
-| #76 | PROD_IMAGE_TAG bump to v2.2.0 | — |
-| #79 | .meridian/ memory backup | Author (3 review rounds) |
-| #80 | Config best practices docs | Issue reporter |
-| #83 | Cross-team automation (CODEOWNERS, release-notify, CI validation) | Reviewer (approved) |
-| #85 | .meridian/ memory sync | Author |
-| #86 | 30 CodeQL security fixes | Reviewer (approved) |
-| #87 | Automated sensitive data scanning (16 rules) | Reviewer (approved) + RFC #89 input |
+### Issues Filed & Resolved (all 7 closed)
+
+| Issue | Priority | Specialist | Resolution |
+|-------|----------|-----------|------------|
+| #67 | P0 | Dockhand | deploy.sh Unicode fix (PR #73) |
+| #68 | P1 | Dockhand | newui Docker profile (PR #73) |
+| #69 | P1 | Crane | Reverse proxy docs (PR #73) |
+| #70 | P0 | Dockhand | PROD_IMAGE_TAG (PR #73) |
+| #71 | P1 | Signal+Vault | Cookie/CORS/WebSocket (PR #73+#74) |
+| #72 | P2 | Compass | Collaborator onboarding (PR #73) |
+| #78 | P2 | Compass | Config best practices (PR #80) |
+
+### PRs — Meridian Authored
+
+| PR | Status | Review Rounds |
+|----|--------|---------------|
+| #79 | Merged | 3 rounds (redacted IP per Hawk) |
+| #85 | Merged | 1 round |
+| #91 | Open | Final session sync |
+
+### PRs — Meridian Reviewed & Approved
+
+| PR | Description |
+|----|-------------|
+| #83 | Cross-team automation (CODEOWNERS, release-notify, CI validation) |
+| #86 | 30 CodeQL security fixes (path injection, stack trace, PBKDF2, XSS) |
+| #87 | Automated sensitive data scanning (16 rules, TruffleHog + custom) |
 
 ### RFCs Resolved
 
 | RFC | Topic | Outcome |
 |-----|-------|---------|
-| #82 | Cross-team automation | Option D agreed: CODEOWNERS + release-notify + CI validation |
-| #89 | Sensitive data classification | 16 scanning rules, no file-path exceptions, Category 4 = warning |
+| #82 | Cross-team automation | CODEOWNERS + release-notify + CI validation + 48h SLA |
+| #89 | Sensitive data classification | 16 rules, no file-path exceptions, Category 4 = warning |
 
-### Investor Rules (all saved to memory)
+### Investor Rules (all saved to feedback memory files)
 
-1. Use .env config files, not CLI flags
-2. Delegate to specialists, no bottleneck
-3. Author disclosure on all content
-4. PR review transparency
-5. Detailed logging
-6. Always backup memory to GitHub
-7. Vault must scan before every GitHub push
+1. `feedback_config_over_cli.md` — use .env files, not CLI flags
+2. `feedback_delegate_no_bottleneck.md` — delegate to specialists
+3. `feedback_author_disclosure.md` — identify yourself on all content
+4. `feedback_pr_review_process.md` — PR comments visible on GitHub
+5. `feedback_detailed_logging.md` — thorough logging
+6. `feedback_vault_review_before_push.md` — Vault scans before every GitHub push
+
+### Key Learnings
+
+- Local MEMORY.md must also use redacted descriptions (root cause of repeated IP leak)
+- `docker-compose.override.yml` is the correct way to customize without editing upstream compose file
+- `!override` directive replaces merged sequences (ports, volumes) in Compose v5+
+- Cross-team CODEOWNERS with SLA prevents bottleneck while ensuring review
+- Automated CI scanning catches what manual review misses


### PR DESCRIPTION
## Summary

- Adds `scripts/meridian-backup.sh` — automated memory backup with built-in Vault security scan
- Syncs latest memory: session log, issues tracker, backup rules, cross-team agreement
- Script skips `meridian_server.md` during sync to prevent re-introducing redacted sensitive data

## What the script does

1. Copies memory files from local `.claude/` to `.meridian/` (excluding `meridian_server.md`)
2. Runs Vault security scan (IPs, port bindings, sensitive paths)
3. Blocks push if scan fails
4. Creates branch, commits, and pushes

## Test plan

- [x] Script catches `124.197.31.140` when present (exit 1, blocked)
- [x] Script passes when `meridian_server.md` is excluded from sync
- [x] No sensitive data in any `.meridian/` file

Author: Compass (Diana Reeves), Deployment Lead — Team Meridian

🤖 Generated with [Claude Code](https://claude.com/claude-code)