### PR TITLE
chore: clean remaining meridian references from CHANGELOG and metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Features
 
-* **ci:** automated cross-team collaboration — CODEOWNERS + release notify + deploy validation ([#83](https://github.com/volehuy1998/subtitle-generator/issues/83)) ([7b3020a](https://github.com/volehuy1998/subtitle-generator/commit/7b3020a3ebfc76dad7d3cf0ef51a74a2c3501bad))
+* **ci:** automated deployment collaboration — CODEOWNERS + release notify + deploy validation ([#83](https://github.com/volehuy1998/subtitle-generator/issues/83)) ([7b3020a](https://github.com/volehuy1998/subtitle-generator/commit/7b3020a3ebfc76dad7d3cf0ef51a74a2c3501bad))
 * **ci:** automated sensitive data scanning to prevent information leaks ([#87](https://github.com/volehuy1998/subtitle-generator/issues/87)) ([90f5f82](https://github.com/volehuy1998/subtitle-generator/commit/90f5f82f5c04926a3a5dff97c59374fab01c3b72))
 
 

--- a/data/security_assertions.json
+++ b/data/security_assertions.json
@@ -5,7 +5,7 @@
     "sha": "10f931c",
     "sha_full": "10f931c24f98b2de869d0ed283aa3d638ad930dc",
     "datetime": "2026-03-15T06:13:56+07:00",
-    "message": "chore: remove all Meridian team references from repository"
+    "message": "chore: remove external team references from repository"
   },
   "assertions": [
     {


### PR DESCRIPTION
## Summary

- Updates CHANGELOG.md v2.3.0: "cross-team collaboration" → "deployment collaboration"
- Cleans security_assertions.json commit message reference

Also completed (outside this PR, via GitHub API):
- Updated v2.3.0 release notes to match
- Renamed 5 PR titles (#79, #83, #85, #91, #101)
- Renamed 5 issue titles (#37, #82, #89, #96, #100)
- Removed `meridian` label from issues #89, #96, #100 and PRs #91, #101
- Deleted the `meridian` label from the repository

Closes #107

**[Atlas] (Tech Lead)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)