### PR TITLE
fix: correct team member count in .sentinel/ frontmatter

### DIFF
--- a/.sentinel/team_structure.md
+++ b/.sentinel/team_structure.md
@@ -1,6 +1,6 @@
 ---
 name: team_structure
-description: SubForge engineering team — 11 members with nicknames, roles, Google standards checklists, and agent prompt templates for each role
+description: SubForge engineering team — 12 members (including Atlas) with nicknames, roles, Google standards checklists, and agent prompt templates for each role
 type: project
 ---
 


### PR DESCRIPTION
## Summary
Fix frontmatter description: "11 members" → "12 members (including Atlas)"

Found by **Quill (Technical Writer)** during PR #115 review.

## Test plan
- [x] Frontmatter now says 12 members
- [x] Actual roster has 12 engineers (Atlas + 11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)