### PR TITLE
fix(health): replace asyncio.timeout for Python 3.10 compatibility

### DIFF
--- a/app/services/query_layer.py
+++ b/app/services/query_layer.py
@@ -290,13 +290,17 @@ async def export_tasks_json(status: str = None, limit: int = 10000) -> list[dict
 # ── DB Health Check ──
 
 
+async def _db_health_ping() -> None:
+    """Execute a simple SELECT 1 to verify database connectivity."""
+    async with get_session() as session:
+        await session.execute(text("SELECT 1"))
+
+
 async def check_db_health() -> dict:
     """Check database health: pool status and query latency."""
     try:
         start = time.time()
-        async with asyncio.timeout(3):
-            async with get_session() as session:
-                await session.execute(text("SELECT 1"))
+        await asyncio.wait_for(_db_health_ping(), timeout=3.0)
         latency_ms = round((time.time() - start) * 1000, 2)
         return {
             "status": "healthy",

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -31,13 +31,16 @@ When the script finishes it prints the live URLs and useful management commands.
 
 | Requirement | Notes |
 |---|---|
-| Ubuntu Server 24.04 LTS | Other Debian-based distros may work but are untested |
+| Ubuntu Server 22.04 or 24.04 LTS | Other Debian-based distros may work but are untested |
+| Python 3.10+ | Installed by default on Ubuntu 22.04+ (3.10) and 24.04+ (3.12) |
 | Root / sudo access | The script must run as root |
 | Public IP + DNS (prod) | Your domain must point to this server before running |
 | Ports 80 and 443 open (prod) | 80 is used briefly for the ACME challenge, then for HTTP→HTTPS redirect |
 | Port 8000 open (dev) | Only needed for local / private access |
 
 The script installs everything else (Python 3, ffmpeg, git, certbot, Docker, etc.).
+
+> **Note**: Ubuntu 22.04 ships Python 3.10 and Ubuntu 24.04 ships Python 3.12. Both are supported. The deploy script uses the system Python to create a virtual environment.
 
 ---
 


### PR DESCRIPTION
## Summary

**CRITICAL FIX**: `asyncio.timeout()` (Python 3.11+) crashes on Ubuntu 22.04 (Python 3.10), putting the system into permanent critical state and blocking ALL uploads.

Closes #112

## Problem

DVS deployment verification on `meridian-openlabs.shop` (Ubuntu 22.04, Python 3.10) found:
```
AttributeError: module 'asyncio' has no attribute 'timeout'
```
This crashes the DB health check every 5 seconds → `system_critical: true` → ALL operations suspended.

## Fix

Replace `asyncio.timeout(3)` context manager with `asyncio.wait_for(coro, timeout=3.0)` which is available since Python 3.4.

## Changes

| File | Change |
|------|--------|
| `app/services/query_layer.py` | Extract `_db_health_ping()` coroutine, use `asyncio.wait_for()` |
| `docs/DEPLOY.md` | Document Ubuntu 22.04 as supported, add Python version note |

## Test plan

- [x] `ruff check` passes
- [x] All tests pass (1190 passed, 138 skipped)
- [x] Verified `asyncio.wait_for` available in Python 3.10

Found by: **Flint (DVS Lead)** — real-world deployment verification
Fixed by: **Forge (Sr. Backend Engineer)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)