### PR TITLE
security: remove public IP from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -548,7 +548,7 @@ Three pillars:
 ### Current Deployment
 - **openlabs.club** — production (container: `subforge-prod`, port 8000, old interface)
 - **newui.openlabs.club** — Lumen preview (container: `subtitle-generator-newui`, port 8001, `PRELOAD_MODEL=large`)
-- Both are on **localhost** (hostname: `subtitle-generator-engine`, IP: `124.197.31.48`)
+- Both are on **localhost** (hostname: `subtitle-generator-engine`, DNS resolves both domains)
 - Nginx reverse proxies both domains to their respective containers
 - Docker requires `sudo` (user `claude-user` not in docker group)
 - Deploy newui: `sudo docker compose --profile newui up -d --build --force-recreate`

--- a/data/security_assertions.json
+++ b/data/security_assertions.json
@@ -2,10 +2,10 @@
   "last_updated": "2026-03-12T21:28:45.891962+00:00",
   "last_run_commit": "8d085c9",
   "last_security_commit": {
-    "sha": "51a27f3",
-    "sha_full": "51a27f3ca3e53798745ce9dc45604fd4eedc8787",
-    "datetime": "2026-03-16T23:26:36+07:00",
-    "message": "fix(test): resolve ESLint errors in L76-L78 CSS validation tests"
+    "sha": "3f3ba22",
+    "sha_full": "3f3ba22c0b13c74038de131b12fdd8810130c01f",
+    "datetime": "2026-03-17T06:44:50+07:00",
+    "message": "security: remove public IP from CLAUDE.md to pass sensitive data scan"
   },
   "assertions": [
     {


### PR DESCRIPTION
**Atlas (Tech Lead)**

## Summary
- Removed hardcoded public IP `124.197.31.48` from CLAUDE.md deployment section
- DNS domain names are sufficient — no need to expose the server IP in source code
- Fixes the `Sensitive data scan (IPs & custom patterns)` CI check

## Test plan
- [x] `scripts/scan_sensitive.py` reports CLEAN
- [x] No other public IPs in changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)