### PR TITLE
fix(docker): cpu profile uses nginx reverse proxy

### DIFF
--- a/data/security_assertions.json
+++ b/data/security_assertions.json
@@ -2,10 +2,10 @@
   "last_updated": "2026-03-12T21:28:45.891962+00:00",
   "last_run_commit": "8d085c9",
   "last_security_commit": {
-    "sha": "3f3ba22",
-    "sha_full": "3f3ba22c0b13c74038de131b12fdd8810130c01f",
-    "datetime": "2026-03-17T06:44:50+07:00",
-    "message": "security: remove public IP from CLAUDE.md to pass sensitive data scan"
+    "sha": "12cfa73",
+    "sha_full": "12cfa732038446faa8a39130101a449e797f84a2",
+    "datetime": "2026-03-17T14:00:42+07:00",
+    "message": "fix(docker): cpu profile uses nginx reverse proxy instead of direct TLS"
   },
   "assertions": [
     {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,8 @@ services:
       - s3
 
   # ── Single-server (CPU) ─────────────────────────────────────────────────────
-  # Usage: docker compose --profile cpu up -d
+  # Usage: docker compose --profile cpu up -d --build
+  # Serves on 127.0.0.1:8000 behind nginx reverse proxy (TLS terminated by nginx)
 
   subtitle-generator:
     image: subtitle-generator-prod:${PROD_IMAGE_TAG:-latest}
@@ -62,16 +63,13 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - "443:8000"
-      - "80:8080"
+      - "127.0.0.1:8000:8000"
     volumes:
       - ./uploads:/app/uploads
       - ./outputs:/app/outputs
       - ./logs:/app/logs
-      - /etc/letsencrypt/live/${DOMAIN}/fullchain.pem:/certs/fullchain.pem:ro
-      - /etc/letsencrypt/live/${DOMAIN}/privkey.pem:/certs/privkey.pem:ro
     environment:
-      - ENVIRONMENT=prod
+      - ENVIRONMENT=dev
       - ROLE=standalone
       - DATABASE_URL=postgresql+asyncpg://subtitle:subtitle@postgres:5432/subtitle_generator
       - REDIS_URL=redis://redis:6379/0


### PR DESCRIPTION
**Anchor (Infra) — authored**

## Summary
- Changed cpu profile port mapping from `443:8000`/`80:8080` to `127.0.0.1:8000:8000` (behind nginx)
- Removed TLS cert volume mounts (nginx terminates TLS)
- Set `ENVIRONMENT=dev` (nginx handles prod TLS, container runs HTTP)

## Why
The host nginx reverse proxy already binds port 443 for TLS termination. The old cpu profile tried to bind 443 directly, causing deployment failures.

## Test plan
- [x] Deployed to production — `openlabs.club` serving Lumen UI
- [x] Health check passing: `curl http://127.0.0.1:8000/health`
- [x] Prod container untouched during newui deploys

Closes #N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)