### PR TITLE
fix(ui): show visible loading badge during model preload

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -145,6 +145,7 @@ class SystemInfoResponse(BaseModel):
     model_recommendations: dict[str, Literal["ok", "tight", "too_large"]]
     auto_model: str
     diarization: Optional[DiarizationInfo] = None
+    model_preload: Optional[dict] = None
 
 
 class LanguagesResponse(BaseModel):

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -102,7 +102,7 @@ export const api = {
     fetch('/translation/languages').then(r => json<TranslationLanguagesResponse>(r)),
 
   modelStatus: () =>
-    fetch('/api/model-status').then(r => json<ModelPreloadStatus>(r)),
+    fetch('/api/model-status').then(r => json<{ preload: ModelPreloadStatus }>(r)).then(d => d.preload),
 
   tasksBySession: () =>
     fetch('/tasks?session_only=true').then(r => json<TasksResponse>(r)),

--- a/frontend/src/components/transcribe/TranscribeForm.tsx
+++ b/frontend/src/components/transcribe/TranscribeForm.tsx
@@ -316,10 +316,21 @@ export function TranscribeForm({ onUpload }: Props) {
                       </span>
                     )}
                     {preloadState === 'loading' && (
-                      <svg className="animate-spin flex-shrink-0" width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true" aria-label="Loading model">
-                        <circle cx="6" cy="6" r="4.5" stroke="var(--color-primary)" strokeWidth="1.5" opacity="0.25" />
-                        <path d="M10.5 6a4.5 4.5 0 00-4.5-4.5" stroke="var(--color-primary)" strokeWidth="1.5" strokeLinecap="round" />
-                      </svg>
+                      <span
+                        className="inline-flex items-center gap-1 text-xs font-medium px-1.5 rounded-full"
+                        style={{
+                          background: 'var(--color-warning-light, #FEF3C7)',
+                          color: 'var(--color-warning, #D97706)',
+                          fontSize: '9px',
+                          lineHeight: '16px',
+                        }}
+                      >
+                        <svg className="animate-spin flex-shrink-0" width="8" height="8" viewBox="0 0 8 8" fill="none" aria-hidden="true">
+                          <circle cx="4" cy="4" r="3" stroke="currentColor" strokeWidth="1.2" opacity="0.3" />
+                          <path d="M7 4a3 3 0 00-3-3" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+                        </svg>
+                        Loading…
+                      </span>
                     )}
 
                     {/* GPU fit */}


### PR DESCRIPTION
**Pixel (Sr. Frontend) + Forge (Sr. Backend) — authored**

## Summary
- Replace invisible 12px spinner with amber "Loading…" pill badge during model preload
- Fix API client: `modelStatus()` now extracts `.preload` from nested response (polling was broken)
- Add `model_preload` field to `SystemInfoResponse` schema (backend was returning `null`)

## Three bugs fixed
1. **UI**: Tiny spinner → visible amber badge matching "Ready" badge style
2. **API client**: `status.status` was undefined because response is `{preload: {...}}` not flat
3. **Schema**: `SystemInfoResponse` missing `model_preload` field, Pydantic dropped it

## Test plan
- [x] 372 frontend tests pass
- [x] 3295 backend tests pass
- [x] Deployed to newui.openlabs.club — "Ready" badge shows after model loads
- [x] Verified `/system-info` returns `model_preload` with loading/ready status

🤖 Generated with [Claude Code](https://claude.com/claude-code)